### PR TITLE
Add Dependabot for npm and GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,20 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10
+    labels: [dependencies]
+    groups:
+      all:
+        patterns: ["*"]
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10
+    labels: [dependencies]
+    groups:
+      all:
+        patterns: ["*"]


### PR DESCRIPTION
Closes #3

## Summary

- Weekly grouped Dependabot updates for npm dependencies
- Weekly grouped Dependabot updates for GitHub Actions

🤖 Generated with [Claude Code](https://claude.com/claude-code)