### PR TITLE
#21 Bump project version to 1.0.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "playwright-report",
-  "version": "1.0.3",
+  "name": "playwright-report-mcp",
+  "version": "1.0.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "playwright-report",
-      "version": "1.0.3",
+      "name": "playwright-report-mcp",
+      "version": "1.0.4",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.0",
         "zod": "^4.0.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "playwright-report-mcp",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "mcpName": "io.github.hubertgajewski/playwright-report-mcp",
   "description": "MCP server for running Playwright tests and reading structured results — designed for AI agents doing test failure analysis",
   "type": "module",

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/hubertgajewski/playwright-report-mcp",
     "source": "github"
   },
-  "version": "1.0.3",
+  "version": "1.0.4",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "playwright-report-mcp",
-      "version": "1.0.3",
+      "version": "1.0.4",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
Closes #21

Update package.json, package-lock.json, and server.json to version 1.0.4 so the project metadata matches the latest npm and MCP registry release.