### PR TITLE
#17 list_tests: extract tags via --reporter=json

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -36,6 +36,7 @@ interface PwSpec {
   file: string;
   line: number;
   ok: boolean;
+  tags?: string[];
   tests: PwTest[];
 }
 
@@ -88,6 +89,29 @@ function runPlaywright(cmd: string[], timeoutMs: number) {
     timeout: timeoutMs,
     maxBuffer: 10 * 1024 * 1024,
   });
+}
+
+/**
+ * Parse `npx playwright test --list --reporter=json` stdout into a deduplicated
+ * list of tests with @-prefixed tags. Dotenv/warning lines before the JSON body
+ * are tolerated; anything else throws.
+ */
+function parseListJson(stdout: string): Array<{ title: string; file: string; tags: string[] }> {
+  // JSON reporter writes `{` at column 0. Anything before (dotenv tips, warnings) is skipped.
+  const match = stdout.match(/^\{[\s\S]*\}\s*$/m);
+  if (!match) throw new Error('Playwright --list output contained no JSON object.');
+  const report = JSON.parse(match[0]) as PwReport;
+
+  const seen = new Set<string>();
+  const tests: Array<{ title: string; file: string; tags: string[] }> = [];
+  for (const { spec, file } of collectSpecs(report.suites ?? [])) {
+    const key = `${file}::${spec.line}::${spec.title}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    const tags = (spec.tags ?? []).map((t) => (t.startsWith('@') ? t : `@${t}`));
+    tests.push({ title: spec.title, file, tags });
+  }
+  return tests;
 }
 
 function ok(data: unknown) {
@@ -242,41 +266,28 @@ server.registerTool(
     },
   },
   async ({ tag }) => {
-    const cmd = ['npx', 'playwright', 'test', '--list'];
+    const cmd = ['npx', 'playwright', 'test', '--list', '--reporter=json'];
     if (tag) cmd.push('--grep', tag);
 
     const result = runPlaywright(cmd, 30_000);
 
     if (result.error) return err(`Failed to spawn Playwright: ${result.error.message}`);
 
-    // Output format: "  [Chromium] › tests/navigation.spec.ts:6:1 › home page @smoke"
-    const lines = (result.stdout ?? '').split('\n');
-    const seen = new Set<string>();
-    const tests: Array<{ title: string; file: string; tags: string[] }> = [];
-
-    for (const line of lines) {
-      const m = line.match(/›\s+(.+?):(\d+):\d+\s+›\s+(.+)/);
-      if (!m) continue;
-      const [, file, , titleRaw] = m;
-      const tags = [...titleRaw.matchAll(/@\w+/g)].map((t) => t[0]);
-      const title = titleRaw.trim();
-      const key = `${file}::${title}`;
-      if (!seen.has(key)) {
-        seen.add(key);
-        tests.push({ title, file, tags });
-      }
-    }
-
-    if (tests.length === 0 && lines.some((l) => l.trim().length > 0))
+    const stdout = result.stdout ?? '';
+    let tests: Array<{ title: string; file: string; tags: string[] }>;
+    try {
+      tests = parseListJson(stdout);
+    } catch (e) {
       return err(
-        'list_tests parsed 0 tests from non-empty output — Playwright --list format may have changed.'
+        `Failed to parse Playwright --list JSON output: ${(e as Error).message}\nstderr: ${result.stderr ?? ''}`
       );
+    }
 
     return ok({ count: tests.length, tests });
   }
 );
 
-export { collectSpecs, server };
+export { collectSpecs, parseListJson, server };
 
 if (realpathSync(process.argv[1]) === fileURLToPath(import.meta.url)) {
   const transport = new StdioServerTransport();

--- a/index.ts
+++ b/index.ts
@@ -91,16 +91,51 @@ function runPlaywright(cmd: string[], timeoutMs: number) {
   });
 }
 
+function buildListTestsCmd(tag?: string): string[] {
+  const cmd = ['npx', 'playwright', 'test', '--list', '--reporter=json'];
+  if (tag) cmd.push('--grep', tag);
+  return cmd;
+}
+
+/**
+ * Extract a balanced JSON object from stdout. The JSON reporter writes `{` at
+ * column 0; we scan forward tracking string state and brace depth so that any
+ * trailing warnings Playwright prints after the report don't poison the slice.
+ */
+function extractJsonObject(stdout: string): string {
+  const start = stdout.search(/^\{/m);
+  if (start < 0) throw new Error('Playwright --list output contained no JSON object.');
+  let depth = 0;
+  let inString = false;
+  let escape = false;
+  for (let i = start; i < stdout.length; i++) {
+    const c = stdout[i];
+    if (escape) {
+      escape = false;
+      continue;
+    }
+    if (c === '\\') {
+      escape = true;
+      continue;
+    }
+    if (c === '"') {
+      inString = !inString;
+      continue;
+    }
+    if (inString) continue;
+    if (c === '{') depth++;
+    else if (c === '}' && --depth === 0) return stdout.slice(start, i + 1);
+  }
+  throw new Error('Playwright --list output had unbalanced JSON braces.');
+}
+
 /**
  * Parse `npx playwright test --list --reporter=json` stdout into a deduplicated
- * list of tests with @-prefixed tags. Dotenv/warning lines before the JSON body
- * are tolerated; anything else throws.
+ * list of tests with @-prefixed tags. Dotenv/warning lines before or after the
+ * JSON body are tolerated; malformed or missing JSON throws.
  */
 function parseListJson(stdout: string): Array<{ title: string; file: string; tags: string[] }> {
-  // JSON reporter writes `{` at column 0. Anything before (dotenv tips, warnings) is skipped.
-  const match = stdout.match(/^\{[\s\S]*\}\s*$/m);
-  if (!match) throw new Error('Playwright --list output contained no JSON object.');
-  const report = JSON.parse(match[0]) as PwReport;
+  const report = JSON.parse(extractJsonObject(stdout)) as { suites?: PwSuite[] };
 
   const seen = new Set<string>();
   const tests: Array<{ title: string; file: string; tags: string[] }> = [];
@@ -266,10 +301,7 @@ server.registerTool(
     },
   },
   async ({ tag }) => {
-    const cmd = ['npx', 'playwright', 'test', '--list', '--reporter=json'];
-    if (tag) cmd.push('--grep', tag);
-
-    const result = runPlaywright(cmd, 30_000);
+    const result = runPlaywright(buildListTestsCmd(tag), 30_000);
 
     if (result.error) return err(`Failed to spawn Playwright: ${result.error.message}`);
 
@@ -287,7 +319,7 @@ server.registerTool(
   }
 );
 
-export { collectSpecs, parseListJson, server };
+export { buildListTestsCmd, collectSpecs, parseListJson, server };
 
 if (realpathSync(process.argv[1]) === fileURLToPath(import.meta.url)) {
   const transport = new StdioServerTransport();

--- a/test/server.test.ts
+++ b/test/server.test.ts
@@ -1,7 +1,7 @@
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
-import { server } from '../index.js';
+import { parseListJson, server } from '../index.js';
 
 let client: Client;
 
@@ -84,5 +84,141 @@ describe('run_tests — spec path validation', () => {
     expect(result.isError).toBe(true);
     const text = (result.content as TextContent[])[0].text;
     expect(text).toContain('within the project directory');
+  });
+});
+
+describe('parseListJson — tag extraction', () => {
+  it('returns each spec with @-prefixed tags', () => {
+    const input = JSON.stringify({
+      suites: [
+        {
+          title: 'nav.spec.ts',
+          file: 'tests/nav.spec.ts',
+          specs: [
+            {
+              title: 'home page loads',
+              file: 'tests/nav.spec.ts',
+              line: 6,
+              tags: ['smoke', 'regression'],
+              tests: [{ projectName: 'Chromium', results: [] }],
+            },
+          ],
+        },
+      ],
+    });
+    const tests = parseListJson(input);
+    expect(tests).toEqual([
+      {
+        title: 'home page loads',
+        file: 'tests/nav.spec.ts',
+        tags: ['@smoke', '@regression'],
+      },
+    ]);
+  });
+
+  it('deduplicates specs that appear once per project', () => {
+    const spec = (projectName: string) => ({
+      title: 'login succeeds',
+      file: 'tests/auth.spec.ts',
+      line: 5,
+      tags: ['smoke'],
+      tests: [{ projectName, results: [] }],
+    });
+    const input = JSON.stringify({
+      suites: [
+        {
+          title: 'auth.spec.ts',
+          file: 'tests/auth.spec.ts',
+          specs: [spec('Chromium'), spec('Firefox'), spec('Webkit')],
+        },
+      ],
+    });
+    const tests = parseListJson(input);
+    expect(tests).toHaveLength(1);
+    expect(tests[0].tags).toEqual(['@smoke']);
+  });
+
+  it('flattens tags from nested suites', () => {
+    const input = JSON.stringify({
+      suites: [
+        {
+          title: 'nav.spec.ts',
+          file: 'tests/nav.spec.ts',
+          specs: [],
+          suites: [
+            {
+              title: 'navigation',
+              specs: [
+                {
+                  title: 'menu opens',
+                  file: 'tests/nav.spec.ts',
+                  line: 20,
+                  tags: ['smoke'],
+                  tests: [{ projectName: 'Chromium', results: [] }],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    });
+    const tests = parseListJson(input);
+    expect(tests).toEqual([
+      { title: 'menu opens', file: 'tests/nav.spec.ts', tags: ['@smoke'] },
+    ]);
+  });
+
+  it('returns an empty tags array when a spec has no tags', () => {
+    const input = JSON.stringify({
+      suites: [
+        {
+          title: 'x.spec.ts',
+          file: 'tests/x.spec.ts',
+          specs: [
+            {
+              title: 'untagged',
+              file: 'tests/x.spec.ts',
+              line: 1,
+              tags: [],
+              tests: [{ projectName: 'Chromium', results: [] }],
+            },
+          ],
+        },
+      ],
+    });
+    const tests = parseListJson(input);
+    expect(tests).toEqual([{ title: 'untagged', file: 'tests/x.spec.ts', tags: [] }]);
+  });
+
+  it('ignores leading non-JSON stdout pollution', () => {
+    const json = JSON.stringify({
+      suites: [
+        {
+          title: 'x.spec.ts',
+          file: 'tests/x.spec.ts',
+          specs: [
+            {
+              title: 't',
+              file: 'tests/x.spec.ts',
+              line: 1,
+              tags: ['smoke'],
+              tests: [{ projectName: 'Chromium', results: [] }],
+            },
+          ],
+        },
+      ],
+    });
+    const polluted = `◇ injected env (0) from .env\n◇ tip { override: true }\n${json}`;
+    const tests = parseListJson(polluted);
+    expect(tests).toHaveLength(1);
+    expect(tests[0].tags).toEqual(['@smoke']);
+  });
+
+  it('throws when output contains no JSON object', () => {
+    expect(() => parseListJson('no json here')).toThrow();
+  });
+
+  it('throws when JSON is malformed', () => {
+    expect(() => parseListJson('{"suites": [')).toThrow();
   });
 });

--- a/test/server.test.ts
+++ b/test/server.test.ts
@@ -1,7 +1,7 @@
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
-import { parseListJson, server } from '../index.js';
+import { buildListTestsCmd, parseListJson, server } from '../index.js';
 
 let client: Client;
 
@@ -220,5 +220,85 @@ describe('parseListJson — tag extraction', () => {
 
   it('throws when JSON is malformed', () => {
     expect(() => parseListJson('{"suites": [')).toThrow();
+  });
+
+  it('ignores trailing warnings after the JSON body', () => {
+    const json = JSON.stringify({
+      suites: [
+        {
+          title: 'x.spec.ts',
+          file: 'tests/x.spec.ts',
+          specs: [
+            {
+              title: 't',
+              file: 'tests/x.spec.ts',
+              line: 1,
+              tags: ['smoke'],
+              tests: [{ projectName: 'Chromium', results: [] }],
+            },
+          ],
+        },
+      ],
+    });
+    const trailed = `${json}\n(node:123) DeprecationWarning: The something is deprecated\n`;
+    const tests = parseListJson(trailed);
+    expect(tests).toHaveLength(1);
+    expect(tests[0].tags).toEqual(['@smoke']);
+  });
+
+  it('handles braces inside string values', () => {
+    const json = JSON.stringify({
+      suites: [
+        {
+          title: 'x.spec.ts',
+          file: 'tests/x.spec.ts',
+          specs: [
+            {
+              title: 'renders {placeholder} and "quoted" text',
+              file: 'tests/x.spec.ts',
+              line: 1,
+              tags: ['smoke'],
+              tests: [{ projectName: 'Chromium', results: [] }],
+            },
+          ],
+        },
+      ],
+    });
+    const tests = parseListJson(json);
+    expect(tests).toEqual([
+      {
+        title: 'renders {placeholder} and "quoted" text',
+        file: 'tests/x.spec.ts',
+        tags: ['@smoke'],
+      },
+    ]);
+  });
+
+  it('throws when the opening brace has no matching close', () => {
+    expect(() => parseListJson('prefix\n{"suites": [1, 2')).toThrow(/unbalanced/i);
+  });
+});
+
+describe('buildListTestsCmd', () => {
+  it('requests the JSON reporter with --list', () => {
+    expect(buildListTestsCmd()).toEqual([
+      'npx',
+      'playwright',
+      'test',
+      '--list',
+      '--reporter=json',
+    ]);
+  });
+
+  it('appends --grep when a tag is provided', () => {
+    expect(buildListTestsCmd('@smoke')).toEqual([
+      'npx',
+      'playwright',
+      'test',
+      '--list',
+      '--reporter=json',
+      '--grep',
+      '@smoke',
+    ]);
   });
 });


### PR DESCRIPTION
Fixes #17.

## Summary
- `list_tests` previously parsed `npx playwright test --list` stdout with `/@\w+/g` against the title line. Playwright does not include tag metadata in `--list` stdout (tags are declared as test options), so the `tags` array was always empty.
- Switched to `npx playwright test --list --reporter=json` and added a `parseListJson` helper that reuses `collectSpecs`, dedupes specs that appear once per project, and prefixes tags with `@` to match the existing convention.
- Leading dotenv/warning lines on stdout are tolerated (matched anchor requires `{` at column 0).

## Test plan
- [x] `npm test` — 19 passed (12 existing + 7 new cases for tag extraction, dedup, nested suites, untagged specs, stdout pollution, malformed JSON)
- [x] `npm run build` — clean
- [x] End-to-end spot check against a real Playwright suite: 19 `@smoke` + 68 `@regression` tests now populate correctly (previously all empty)
