### PR TITLE
#23 run_tests: accept optional timeout parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,7 @@ Runs the Playwright test suite and returns structured pass/fail results.
 | `spec` | string (optional) | Spec file path relative to the project directory, e.g. `tests/login.spec.ts`. Must stay within the project directory. |
 | `browser` | enum (optional) | `Chromium`, `Firefox`, `Webkit`, `Mobile Chrome`, `Mobile Safari` |
 | `tag` | string (optional) | Tag filter, e.g. `@smoke` |
+| `timeout` | integer (optional) | Timeout in seconds for the whole test run. Defaults to `300`. Use a larger value for long suites or a smaller one to fail fast. |
 
 Returns: exit code, run stats, and a summary of all tests with status, duration, and error per project.
 

--- a/index.ts
+++ b/index.ts
@@ -171,9 +171,15 @@ server.registerTool(
         .enum(['Chromium', 'Firefox', 'Webkit', 'Mobile Chrome', 'Mobile Safari'])
         .optional(),
       tag: z.string().optional().describe('Tag filter, e.g. @smoke or @regression'),
+      timeout: z
+        .number()
+        .int()
+        .positive()
+        .optional()
+        .describe('Timeout in seconds for the whole test run. Defaults to 300.'),
     },
   },
-  async ({ spec, browser, tag }) => {
+  async ({ spec, browser, tag, timeout }) => {
     const cmd = ['npx', 'playwright', 'test'];
     if (spec) {
       const resolved = resolve(PW_DIR, spec);
@@ -184,7 +190,7 @@ server.registerTool(
     if (browser) cmd.push('--project', browser);
     if (tag) cmd.push('--grep', tag);
 
-    const result = runPlaywright(cmd, 300_000);
+    const result = runPlaywright(cmd, timeout ? timeout * 1000 : 300_000);
 
     if (result.error) return err(`Failed to spawn Playwright: ${result.error.message}`);
 

--- a/test/server.test.ts
+++ b/test/server.test.ts
@@ -1,7 +1,19 @@
-import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
+
+vi.mock('child_process', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('child_process')>();
+  return {
+    ...actual,
+    spawnSync: vi.fn(() => ({ status: 0, stdout: '', stderr: '' })),
+  };
+});
+
+import { spawnSync } from 'child_process';
 import { buildListTestsCmd, parseListJson, server } from '../index.js';
+
+const spawnSyncMock = spawnSync as unknown as ReturnType<typeof vi.fn>;
 
 let client: Client;
 
@@ -84,6 +96,27 @@ describe('run_tests — spec path validation', () => {
     expect(result.isError).toBe(true);
     const text = (result.content as TextContent[])[0].text;
     expect(text).toContain('within the project directory');
+  });
+});
+
+describe('run_tests — timeout', () => {
+  beforeEach(() => spawnSyncMock.mockClear());
+
+  it('defaults to 300 seconds when timeout is omitted', async () => {
+    await client.callTool({ name: 'run_tests', arguments: {} });
+    expect(spawnSyncMock).toHaveBeenCalledTimes(1);
+    expect(spawnSyncMock.mock.calls[0][2]).toMatchObject({ timeout: 300_000 });
+  });
+
+  it('passes the custom timeout to spawnSync in milliseconds', async () => {
+    await client.callTool({ name: 'run_tests', arguments: { timeout: 60 } });
+    expect(spawnSyncMock).toHaveBeenCalledTimes(1);
+    expect(spawnSyncMock.mock.calls[0][2]).toMatchObject({ timeout: 60_000 });
+  });
+
+  it('rejects non-positive timeout values', async () => {
+    const result = await client.callTool({ name: 'run_tests', arguments: { timeout: 0 } });
+    expect(result.isError).toBe(true);
   });
 });
 


### PR DESCRIPTION
Closes #23.

## Summary

- `run_tests` now accepts an optional `timeout` parameter (positive integer, seconds)
- When provided, it is passed to `spawnSync` as `timeout * 1000` ms
- When omitted, behaviour is unchanged: the run uses the existing 300 s default

## Test plan

- [x] `npm run build` — clean TypeScript compile
- [x] `npm test` — 27 pass (3 new)
  - default 300000 ms when `timeout` is omitted
  - custom value is forwarded in ms (`timeout: 60` → `60000`)
  - non-positive values rejected by the schema
- [x] Existing spec-path-validation and attachment tests still pass
