### PR TITLE
#40 tests: cover error paths and list_tests handler

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,9 +17,70 @@
       },
       "devDependencies": {
         "@types/node": "^25.5.0",
+        "@vitest/coverage-v8": "^4.1.4",
         "typescript": "^6.0.2",
         "vitest": "^4.1.1"
       },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.2.tgz",
+      "integrity": "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.0"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
+      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.28.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+      "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=18"
       }
@@ -70,12 +131,33 @@
         "hono": "^4"
       }
     },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
     },
     "node_modules/@modelcontextprotocol/sdk": {
       "version": "1.29.0",
@@ -463,6 +545,37 @@
         "undici-types": "~7.19.0"
       }
     },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.4.tgz",
+      "integrity": "sha512-x7FptB5oDruxNPDNY2+S8tCh0pcq7ymCe1gTHcsp733jYjrJl8V1gMUlVysuCD9Kz46Xz9t1akkv08dPcYDs1w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@bcoe/v8-coverage": "^1.0.2",
+        "@vitest/utils": "4.1.4",
+        "ast-v8-to-istanbul": "^1.0.0",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-reports": "^3.2.0",
+        "magicast": "^0.5.2",
+        "obug": "^2.1.1",
+        "std-env": "^4.0.0-rc.1",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "4.1.4",
+        "vitest": "4.1.4"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@vitest/expect": {
       "version": "4.1.4",
       "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.4.tgz",
@@ -630,6 +743,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-1.0.0.tgz",
+      "integrity": "sha512-1fSfIwuDICFA4LKkCzRPO7F0hzFf0B7+Xqrl27ynQaa+Rh0e1Es0v6kWHPott3lU10AyAr7oKHa65OppjLn3Rg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.31",
+        "estree-walker": "^3.0.3",
+        "js-tokens": "^10.0.0"
       }
     },
     "node_modules/body-parser": {
@@ -1153,6 +1278,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/has-symbols": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
@@ -1185,6 +1320,13 @@
       "engines": {
         "node": ">=16.9.0"
       }
+    },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/http-errors": {
       "version": "2.0.1",
@@ -1258,6 +1400,45 @@
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "license": "ISC"
     },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/jose": {
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.2.tgz",
@@ -1266,6 +1447,13 @@
       "funding": {
         "url": "https://github.com/sponsors/panva"
       }
+    },
+    "node_modules/js-tokens": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/json-schema-traverse": {
       "version": "1.0.0",
@@ -1548,6 +1736,34 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/magicast": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.2.tgz",
+      "integrity": "sha512-E3ZJh4J3S9KfwdjZhe2afj6R9lGIN5Pher1pF39UGrXRqq/VDaGVIGN13BjHd2u8B61hArAGOnso7nBOouW3TQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/math-intrinsics": {
@@ -1902,6 +2118,19 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "license": "MIT"
     },
+    "node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/send": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
@@ -2085,6 +2314,19 @@
       "integrity": "sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/tinybench": {
       "version": "2.9.0",

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
   },
   "devDependencies": {
     "@types/node": "^25.5.0",
+    "@vitest/coverage-v8": "^4.1.4",
     "typescript": "^6.0.2",
     "vitest": "^4.1.1"
   }

--- a/test/server.test.ts
+++ b/test/server.test.ts
@@ -1,6 +1,10 @@
-import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
+import { unlinkSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import { fileURLToPath } from 'url';
+import { stats, suites } from './fixtures/data.js';
 
 vi.mock('child_process', async (importOriginal) => {
   const actual = await importOriginal<typeof import('child_process')>();
@@ -14,6 +18,25 @@ import { spawnSync } from 'child_process';
 import { buildListTestsCmd, parseListJson, server } from '../index.js';
 
 const spawnSyncMock = spawnSync as unknown as ReturnType<typeof vi.fn>;
+
+const resultsDir = fileURLToPath(new URL('./fixtures/test-results', import.meta.url));
+const resultsFile = join(resultsDir, 'results.json');
+
+function writeDefaultReport() {
+  writeFileSync(resultsFile, JSON.stringify({ suites, stats }, null, 2));
+}
+
+function writeCustomReport(report: unknown) {
+  writeFileSync(resultsFile, JSON.stringify(report));
+}
+
+function deleteReport() {
+  try {
+    unlinkSync(resultsFile);
+  } catch {
+    // already gone
+  }
+}
 
 let client: Client;
 
@@ -332,6 +355,483 @@ describe('buildListTestsCmd', () => {
       '--reporter=json',
       '--grep',
       '@smoke',
+    ]);
+  });
+});
+
+describe('run_tests — spawn failure', () => {
+  beforeEach(() => spawnSyncMock.mockClear());
+
+  it('returns error when Playwright cannot be spawned', async () => {
+    spawnSyncMock.mockReturnValueOnce({
+      error: new Error('ENOENT'),
+      stdout: '',
+      stderr: '',
+    });
+    const result = await client.callTool({ name: 'run_tests', arguments: {} });
+    expect(result.isError).toBe(true);
+    const text = (result.content as TextContent[])[0].text;
+    expect(text).toContain('Failed to spawn Playwright');
+    expect(text).toContain('ENOENT');
+  });
+});
+
+describe('run_tests — missing results.json', () => {
+  beforeEach(() => deleteReport());
+  afterEach(() => writeDefaultReport());
+
+  it('returns error referencing stderr when the report file is absent', async () => {
+    spawnSyncMock.mockReturnValueOnce({
+      status: 1,
+      stdout: '',
+      stderr: 'reporter failed to write output',
+    });
+    const result = await client.callTool({ name: 'run_tests', arguments: {} });
+    expect(result.isError).toBe(true);
+    const text = (result.content as TextContent[])[0].text;
+    expect(text).toContain('results.json was not found');
+    expect(text).toContain('reporter failed to write output');
+  });
+});
+
+describe('run_tests — happy-path summarization', () => {
+  it('returns stats and per-test statuses sourced from the last results.json', async () => {
+    const data = parseResult(await client.callTool({ name: 'run_tests', arguments: {} }));
+    expect(data.stats).toEqual(stats);
+    expect(data.tests).toHaveLength(2);
+    const byTitle = Object.fromEntries(
+      data.tests.map((t: { title: string }) => [t.title, t])
+    );
+    expect(byTitle['login succeeds'].ok).toBe(true);
+    expect(byTitle['login succeeds'].results[0]).toMatchObject({
+      project: 'Chromium',
+      status: 'passed',
+      error: null,
+    });
+    expect(byTitle['login fails with wrong password'].ok).toBe(false);
+    expect(byTitle['login fails with wrong password'].results[0]).toMatchObject({
+      project: 'Chromium',
+      status: 'failed',
+    });
+    expect(byTitle['login fails with wrong password'].results[0].error).toContain('Login failed');
+  });
+});
+
+describe('get_failed_tests — missing report', () => {
+  beforeEach(() => deleteReport());
+  afterEach(() => writeDefaultReport());
+
+  it('returns error when results.json is missing', async () => {
+    const result = await client.callTool({ name: 'get_failed_tests', arguments: {} });
+    expect(result.isError).toBe(true);
+    expect((result.content as TextContent[])[0].text).toContain('No results.json');
+  });
+});
+
+describe('get_test_attachment — error gates', () => {
+  afterEach(() => writeDefaultReport());
+
+  it('returns error when results.json is missing', async () => {
+    deleteReport();
+    const result = await client.callTool({
+      name: 'get_test_attachment',
+      arguments: { testTitle: 'anything', attachmentName: 'anything' },
+    });
+    expect(result.isError).toBe(true);
+    expect((result.content as TextContent[])[0].text).toContain('No results.json');
+  });
+
+  it('rejects binary attachments with a descriptive error', async () => {
+    const binaryPath = join(resultsDir, 'screenshot.png');
+    writeFileSync(binaryPath, 'fake-png-bytes');
+    writeCustomReport({
+      suites: [
+        {
+          title: 'x.spec.ts',
+          file: 'tests/x.spec.ts',
+          specs: [
+            {
+              title: 'binary test',
+              file: 'tests/x.spec.ts',
+              line: 1,
+              ok: false,
+              tests: [
+                {
+                  projectName: 'Chromium',
+                  status: 'unexpected',
+                  results: [
+                    {
+                      status: 'failed',
+                      duration: 10,
+                      attachments: [
+                        { name: 'screenshot', contentType: 'image/png', path: binaryPath },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+      stats: { expected: 0, unexpected: 1, skipped: 0, duration: 10 },
+    });
+
+    const result = await client.callTool({
+      name: 'get_test_attachment',
+      arguments: { testTitle: 'binary test', attachmentName: 'screenshot' },
+    });
+    expect(result.isError).toBe(true);
+    const text = (result.content as TextContent[])[0].text;
+    expect(text).toContain('binary');
+    expect(text).toContain('image/png');
+    unlinkSync(binaryPath);
+  });
+
+  it('rejects attachments larger than MAX_BYTES', async () => {
+    const bigPath = join(resultsDir, 'big.txt');
+    writeFileSync(bigPath, 'x'.repeat(1_000_001));
+    writeCustomReport({
+      suites: [
+        {
+          title: 'x.spec.ts',
+          file: 'tests/x.spec.ts',
+          specs: [
+            {
+              title: 'big test',
+              file: 'tests/x.spec.ts',
+              line: 1,
+              ok: false,
+              tests: [
+                {
+                  projectName: 'Chromium',
+                  status: 'unexpected',
+                  results: [
+                    {
+                      status: 'failed',
+                      duration: 10,
+                      attachments: [
+                        { name: 'diag', contentType: 'text/plain', path: bigPath },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+      stats: { expected: 0, unexpected: 1, skipped: 0, duration: 10 },
+    });
+
+    const result = await client.callTool({
+      name: 'get_test_attachment',
+      arguments: { testTitle: 'big test', attachmentName: 'diag' },
+    });
+    expect(result.isError).toBe(true);
+    expect((result.content as TextContent[])[0].text).toContain('too large');
+    unlinkSync(bigPath);
+  });
+
+  it('falls through to "not found" when the attachment file is missing from disk', async () => {
+    writeCustomReport({
+      suites: [
+        {
+          title: 'x.spec.ts',
+          file: 'tests/x.spec.ts',
+          specs: [
+            {
+              title: 'ghost test',
+              file: 'tests/x.spec.ts',
+              line: 1,
+              ok: false,
+              tests: [
+                {
+                  projectName: 'Chromium',
+                  status: 'unexpected',
+                  results: [
+                    {
+                      status: 'failed',
+                      duration: 10,
+                      attachments: [
+                        {
+                          name: 'diag',
+                          contentType: 'text/plain',
+                          path: join(resultsDir, 'does-not-exist.txt'),
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+      stats: { expected: 0, unexpected: 1, skipped: 0, duration: 10 },
+    });
+
+    const result = await client.callTool({
+      name: 'get_test_attachment',
+      arguments: { testTitle: 'ghost test', attachmentName: 'diag' },
+    });
+    expect(result.isError).toBe(true);
+    expect((result.content as TextContent[])[0].text).toContain('not found');
+  });
+});
+
+describe('run_tests — command construction', () => {
+  beforeEach(() => spawnSyncMock.mockClear());
+
+  it('passes spec, browser, and tag through to the Playwright command', async () => {
+    await client.callTool({
+      name: 'run_tests',
+      arguments: {
+        spec: 'tests/auth.spec.ts',
+        browser: 'Chromium',
+        tag: '@smoke',
+      },
+    });
+    const args = spawnSyncMock.mock.calls[0][1] as string[];
+    expect(args).toContain('--project');
+    expect(args).toContain('Chromium');
+    expect(args).toContain('--grep');
+    expect(args).toContain('@smoke');
+    expect(args.some((a) => a.endsWith('tests/auth.spec.ts'))).toBe(true);
+  });
+});
+
+describe('run_tests — edge cases in spawn result', () => {
+  afterEach(() => writeDefaultReport());
+
+  it('reports exitCode -1 when spawn result has no status field', async () => {
+    spawnSyncMock.mockReturnValueOnce({ stdout: '', stderr: '' });
+    const data = parseResult(await client.callTool({ name: 'run_tests', arguments: {} }));
+    expect(data.exitCode).toBe(-1);
+  });
+
+  it('reports unknown status and zero duration for tests with no result attempts', async () => {
+    writeCustomReport({
+      suites: [
+        {
+          title: 'x.spec.ts',
+          file: 'tests/x.spec.ts',
+          specs: [
+            {
+              title: 'never ran',
+              file: 'tests/x.spec.ts',
+              line: 1,
+              ok: true,
+              tests: [{ projectName: 'Chromium', status: 'expected', results: [] }],
+            },
+          ],
+        },
+      ],
+      stats: { expected: 1, unexpected: 0, skipped: 0, duration: 0 },
+    });
+    const data = parseResult(await client.callTool({ name: 'run_tests', arguments: {} }));
+    expect(data.tests[0].results[0]).toMatchObject({
+      project: 'Chromium',
+      status: 'unknown',
+      duration: 0,
+      error: null,
+    });
+  });
+
+  it('handles spawn result with no stderr field when the report is missing', async () => {
+    deleteReport();
+    spawnSyncMock.mockReturnValueOnce({ status: 1 });
+    const result = await client.callTool({ name: 'run_tests', arguments: {} });
+    expect(result.isError).toBe(true);
+    expect((result.content as TextContent[])[0].text).toMatch(/stderr:\s*$/);
+  });
+});
+
+describe('get_failed_tests — edge cases', () => {
+  afterEach(() => writeDefaultReport());
+
+  it('returns the failing spec with empty failures when its tests have no result attempts', async () => {
+    writeCustomReport({
+      suites: [
+        {
+          title: 'x.spec.ts',
+          file: 'tests/x.spec.ts',
+          specs: [
+            {
+              title: 'empty results',
+              file: 'tests/x.spec.ts',
+              line: 1,
+              ok: false,
+              tests: [{ projectName: 'Chromium', status: 'unexpected', results: [] }],
+            },
+          ],
+        },
+      ],
+      stats: { expected: 0, unexpected: 1, skipped: 0, duration: 0 },
+    });
+    const data = parseResult(await client.callTool({ name: 'get_failed_tests', arguments: {} }));
+    expect(data.failedCount).toBe(1);
+    expect(data.tests[0].failures).toEqual([]);
+  });
+});
+
+describe('get_test_attachment — skips entries without result attempts', () => {
+  afterEach(() => writeDefaultReport());
+
+  it('continues past tests whose results array is empty and returns not-found', async () => {
+    writeCustomReport({
+      suites: [
+        {
+          title: 'x.spec.ts',
+          file: 'tests/x.spec.ts',
+          specs: [
+            {
+              title: 'mixed',
+              file: 'tests/x.spec.ts',
+              line: 1,
+              ok: false,
+              tests: [
+                { projectName: 'Chromium', status: 'unexpected', results: [] },
+                {
+                  projectName: 'Firefox',
+                  status: 'unexpected',
+                  results: [{ status: 'failed', duration: 10, attachments: [] }],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+      stats: { expected: 0, unexpected: 1, skipped: 0, duration: 10 },
+    });
+    const result = await client.callTool({
+      name: 'get_test_attachment',
+      arguments: { testTitle: 'mixed', attachmentName: 'diag' },
+    });
+    expect(result.isError).toBe(true);
+    expect((result.content as TextContent[])[0].text).toContain('not found');
+  });
+});
+
+describe('list_tests — via MCP client', () => {
+  beforeEach(() => spawnSyncMock.mockClear());
+
+  it('returns tests parsed from the JSON reporter output', async () => {
+    const reporterJson = JSON.stringify({
+      suites: [
+        {
+          title: 'nav.spec.ts',
+          file: 'tests/nav.spec.ts',
+          specs: [
+            {
+              title: 'home loads',
+              file: 'tests/nav.spec.ts',
+              line: 3,
+              tags: ['smoke'],
+              tests: [{ projectName: 'Chromium', results: [] }],
+            },
+          ],
+        },
+      ],
+    });
+    spawnSyncMock.mockReturnValueOnce({ status: 0, stdout: reporterJson, stderr: '' });
+
+    const data = parseResult(await client.callTool({ name: 'list_tests', arguments: {} }));
+    expect(data.count).toBe(1);
+    expect(data.tests[0]).toEqual({
+      title: 'home loads',
+      file: 'tests/nav.spec.ts',
+      tags: ['@smoke'],
+    });
+  });
+
+  it('passes --grep to Playwright when a tag filter is provided', async () => {
+    spawnSyncMock.mockReturnValueOnce({ status: 0, stdout: '{"suites":[]}', stderr: '' });
+    await client.callTool({ name: 'list_tests', arguments: { tag: '@smoke' } });
+    const args = spawnSyncMock.mock.calls[0][1] as string[];
+    expect(args).toContain('--grep');
+    expect(args).toContain('@smoke');
+  });
+
+  it('returns error when Playwright cannot be spawned', async () => {
+    spawnSyncMock.mockReturnValueOnce({ error: new Error('ENOENT'), stdout: '', stderr: '' });
+    const result = await client.callTool({ name: 'list_tests', arguments: {} });
+    expect(result.isError).toBe(true);
+    expect((result.content as TextContent[])[0].text).toContain('Failed to spawn Playwright');
+  });
+
+  it('returns error when --list output cannot be parsed as JSON', async () => {
+    spawnSyncMock.mockReturnValueOnce({
+      status: 0,
+      stdout: 'no json here',
+      stderr: 'some warning',
+    });
+    const result = await client.callTool({ name: 'list_tests', arguments: {} });
+    expect(result.isError).toBe(true);
+    const text = (result.content as TextContent[])[0].text;
+    expect(text).toContain('Failed to parse');
+    expect(text).toContain('some warning');
+  });
+
+  it('tolerates spawn result with missing stdout/stderr fields', async () => {
+    spawnSyncMock.mockReturnValueOnce({});
+    const result = await client.callTool({ name: 'list_tests', arguments: {} });
+    expect(result.isError).toBe(true);
+    const text = (result.content as TextContent[])[0].text;
+    expect(text).toContain('Failed to parse');
+    expect(text).toMatch(/stderr:\s*$/);
+  });
+
+  it('returns zero tests when the reporter JSON has no suites field', async () => {
+    spawnSyncMock.mockReturnValueOnce({ status: 0, stdout: '{}', stderr: '' });
+    const data = parseResult(await client.callTool({ name: 'list_tests', arguments: {} }));
+    expect(data).toEqual({ count: 0, tests: [] });
+  });
+});
+
+describe('parseListJson — tag normalization edge cases', () => {
+  it('preserves already @-prefixed tags without doubling', () => {
+    const input = JSON.stringify({
+      suites: [
+        {
+          title: 'x.spec.ts',
+          file: 'tests/x.spec.ts',
+          specs: [
+            {
+              title: 'already prefixed',
+              file: 'tests/x.spec.ts',
+              line: 1,
+              tags: ['@smoke'],
+              tests: [{ projectName: 'Chromium', results: [] }],
+            },
+          ],
+        },
+      ],
+    });
+    expect(parseListJson(input)).toEqual([
+      { title: 'already prefixed', file: 'tests/x.spec.ts', tags: ['@smoke'] },
+    ]);
+  });
+
+  it('defaults to an empty tags array when the tags field is missing', () => {
+    const input = JSON.stringify({
+      suites: [
+        {
+          title: 'x.spec.ts',
+          file: 'tests/x.spec.ts',
+          specs: [
+            {
+              title: 'no tags field',
+              file: 'tests/x.spec.ts',
+              line: 1,
+              tests: [{ projectName: 'Chromium', results: [] }],
+            },
+          ],
+        },
+      ],
+    });
+    expect(parseListJson(input)).toEqual([
+      { title: 'no tags field', file: 'tests/x.spec.ts', tags: [] },
     ]);
   });
 });


### PR DESCRIPTION
## Summary
- Adds unit tests for previously uncovered error paths in `run_tests`, `get_failed_tests`, and `get_test_attachment`, plus end-to-end MCP-client tests for the `list_tests` handler.
- Security-relevant gates now have regression tests: binary content-type rejection, `MAX_BYTES` cap, and the attachment-file-missing fallthrough.
- Adds `@vitest/coverage-v8` to devDependencies so branch coverage can be measured locally.

Branch coverage on `index.ts`: **66.66% -> 95.40%** (49 tests, all passing). The only remaining uncovered lines are the stdio entrypoint guard (331-332), flagged as out of scope in the issue.

Closes #40

## Test plan
- [x] `npx vitest run` -- 49/49 pass
- [x] `npx vitest run --coverage` -- branch coverage >= 90%
- [x] `npm run build` -- clean
