### PR TITLE
#36 ci: add release workflow with version-sync check and categorized notes

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,17 @@
+changelog:
+  exclude:
+    labels:
+      - duplicate
+      - invalid
+      - wontfix
+  categories:
+    - title: Features
+      labels: [enhancement]
+    - title: Bug fixes
+      labels: [bug]
+    - title: Documentation
+      labels: [documentation]
+    - title: Dependencies
+      labels: [dependencies]
+    - title: Other changes
+      labels: ['*']

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,43 @@
+name: Release
+
+on:
+  push:
+    tags: ['v*']
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Verify tag matches version fields
+        run: |
+          tag_version="${GITHUB_REF_NAME#v}"
+          pkg_version=$(jq -r .version package.json)
+          server_version=$(jq -r .version server.json)
+          server_pkg_version=$(jq -r '.packages[0].version' server.json)
+
+          echo "Tag version:               $tag_version"
+          echo "package.json version:      $pkg_version"
+          echo "server.json version:       $server_version"
+          echo "server.json packages[0]:   $server_pkg_version"
+
+          if [ "$tag_version" != "$pkg_version" ] \
+            || [ "$tag_version" != "$server_version" ] \
+            || [ "$tag_version" != "$server_pkg_version" ]; then
+            echo "::error::Tag $GITHUB_REF_NAME does not match all three version fields. Bump package.json, server.json (top-level), and server.json packages[0] to the same value before tagging."
+            exit 1
+          fi
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create "$GITHUB_REF_NAME" \
+            --title "$GITHUB_REF_NAME" \
+            --generate-notes \
+            --verify-tag

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ An MCP (Model Context Protocol) server for running Playwright tests and reading 
 - [Requirements](#requirements)
 - [Troubleshooting](#troubleshooting)
 - [Development](#development)
+- [Cutting a release](#cutting-a-release)
 - [Contributing](#contributing)
 - [License](#license)
 
@@ -320,6 +321,31 @@ npm run test:watch  # watch mode
 ```
 
 Tests use [Vitest](https://vitest.dev/) and cover the `collectSpecs` helper (unit) and all four MCP tools via `InMemoryTransport` (integration). No build step or Playwright installation required to run the test suite.
+
+---
+
+## Cutting a release
+
+Releases are produced by pushing a `v*` tag. A GitHub Actions workflow (`.github/workflows/release.yml`) picks up the tag, verifies the version fields are in sync, and creates a GitHub Release with auto-generated notes categorized per `.github/release.yml` (Features / Bug fixes / Documentation / Dependencies / Other changes).
+
+**Version lives in three places and all three must match before tagging:**
+
+- `package.json` → `version`
+- `server.json` → top-level `version`
+- `server.json` → `packages[0].version`
+
+Bump all three in one PR and merge to `main` before cutting the release. The workflow refuses to create a release if the tag disagrees with any of these values.
+
+**Ritual:**
+
+```bash
+# After the version-bump PR has merged to main:
+git checkout main && git pull
+git tag v1.0.5
+git push origin v1.0.5
+# → .github/workflows/release.yml fires
+# → GitHub Release created with auto-generated, categorized notes
+```
 
 ---
 


### PR DESCRIPTION
Closes #36.

## Summary

Adds the missing "step 2" of the release flow: explicit tag push → GitHub Release with auto-generated, label-categorized notes. Prerequisite for #34 (npm publish) and #35 (MCP registry publish), both of which trigger on `release: { types: [published] }`.

## Changes

- **`.github/release.yml`** — categorizes PRs into Features / Bug fixes / Documentation / Dependencies / Other changes, with top-down matching so the catch-all `["*"]` only collects PRs that didn't match earlier categories. Excludes `duplicate` / `invalid` / `wontfix`.
- **`.github/workflows/release.yml`** — triggers on `push: tags: ['v*']`. `contents: write` only. Step 1 verifies the pushed tag (minus `v`) matches all three version fields (`package.json.version`, `server.json.version`, `server.json.packages[0].version`) and fails loudly otherwise. Step 2 runs `gh release create --generate-notes --verify-tag`.
- **`README.md`** — adds a "Cutting a release" section documenting the tag-push ritual and the three-field version invariant.

## Design choices

- **Native GitHub auto-generated notes** (`.github/release.yml` + `--generate-notes`) rather than a third-party action — no new dependencies.
- **Tag push is the contract** — no `workflow_dispatch`, no commit-message detection.
- **Version-sync check runs before release creation** — failing here is strictly cheaper than letting #34/#35 both fail downstream.
- **Workflow only reads version fields** — never modifies `package.json` or `server.json`.

## Verification

- YAML syntax validated for both files.
- Version-sync shell logic simulated locally with `GITHUB_REF_NAME=v1.0.4` (current repo version): correctly proceeds. With `GITHUB_REF_NAME=v9.9.9`: correctly fails with the mismatch error.
- Existing test suite still passes (49/49).
- End-to-end verification (acceptance criterion final bullet) requires merging this PR and pushing a real tag — that's a post-merge step.

## Acceptance criteria

- [x] `.github/release.yml` exists with the specified categories
- [x] `.github/workflows/release.yml` triggers only on `push: tags: ['v*']`
- [x] Workflow fails before creating a release on version-field mismatch
- [x] Workflow runs `gh release create --generate-notes --verify-tag`
- [x] Workflow never modifies `package.json` or `server.json`
- [x] README documents the tag-push ritual and the three-field invariant
- [ ] End-to-end verified by cutting a real patch release — post-merge step
