### PR TITLE
#42 test: in-repo e2e suite driving the MCP server over StdioClientTransport

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,5 +59,7 @@ jobs:
         if: steps.pw-cache.outputs.cache-hit != 'true'
         run: npx playwright install --with-deps chromium
         working-directory: test/fixtures/pw-project
+      # Fixture already installed above; invoke vitest directly to avoid a
+      # redundant npm ci --prefix that `npm run test:e2e` would otherwise add.
       - name: Run e2e tests
         run: npx vitest run --config vitest.e2e.config.ts

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,3 +35,29 @@ jobs:
         with:
           name: coverage
           path: coverage/
+
+  e2e:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+          cache: 'npm'
+      - run: npm ci
+      - run: npm run build
+      - name: Install fixture project dependencies
+        run: npm ci --prefix test/fixtures/pw-project
+      - name: Cache Playwright browsers
+        id: pw-cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: pw-browsers-${{ hashFiles('test/fixtures/pw-project/package-lock.json') }}
+          restore-keys: pw-browsers-
+      - name: Install Playwright browsers
+        if: steps.pw-cache.outputs.cache-hit != 'true'
+        run: npx playwright install --with-deps chromium
+        working-directory: test/fixtures/pw-project
+      - name: Run e2e tests
+        run: npx vitest run --config vitest.e2e.config.ts

--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,6 @@ dist/
 node_modules/
 coverage/
 test/fixtures/test-results/
+test/fixtures/pw-project/node_modules/
+test/fixtures/pw-project/test-results/
 .mcpregistry_*

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "build": "tsc",
     "start": "node dist/index.js",
     "test": "vitest run",
+    "test:e2e": "npm ci --prefix test/fixtures/pw-project && vitest run --config vitest.e2e.config.ts",
     "test:watch": "vitest"
   },
   "dependencies": {

--- a/test/e2e.test.ts
+++ b/test/e2e.test.ts
@@ -85,10 +85,8 @@ describe.skipIf(SKIP)('MCP server e2e — fixture Playwright project', () => {
     it('returns all tests from the fixture project', async () => {
       const data = parseResult(await client.callTool({ name: 'list_tests', arguments: {} }));
       expect(data.count).toBeGreaterThanOrEqual(3);
-      expect(data.tests).toEqual(
-        expect.arrayContaining([
-          expect.objectContaining({ title: expect.any(String), file: expect.any(String) }),
-        ])
+      expect(data.tests.map((t: { title: string }) => t.title)).toContain(
+        'deliberately fails with attachment'
       );
     });
 
@@ -109,8 +107,7 @@ describe.skipIf(SKIP)('MCP server e2e — fixture Playwright project', () => {
   // get_failed_tests and get_test_attachment have had a chance to read it.
 
   describe('after a full browser test run', () => {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    let runData: any;
+    let runData: Record<string, unknown>;
 
     beforeAll(async () => {
       runData = parseResult(await client.callTool({ name: 'run_tests', arguments: {} }));

--- a/test/e2e.test.ts
+++ b/test/e2e.test.ts
@@ -34,6 +34,8 @@ function chromiumInstalled(): boolean {
 }
 
 const skipReasons: string[] = [];
+if (!existsSync(DIST_INDEX))
+  skipReasons.push('server not built — run: npm run build');
 if (!fixtureInstalled())
   skipReasons.push('fixture not installed — run: npm ci --prefix test/fixtures/pw-project');
 if (!chromiumInstalled())
@@ -82,7 +84,6 @@ describe.skipIf(SKIP)('MCP server e2e — fixture Playwright project', () => {
   describe('list_tests', () => {
     it('returns all tests from the fixture project', async () => {
       const data = parseResult(await client.callTool({ name: 'list_tests', arguments: {} }));
-      // fixture has 3 specs: homepage, smoke, failing
       expect(data.count).toBeGreaterThanOrEqual(3);
       expect(data.tests).toEqual(
         expect.arrayContaining([

--- a/test/e2e.test.ts
+++ b/test/e2e.test.ts
@@ -1,0 +1,177 @@
+/**
+ * End-to-end tests that boot the built dist/index.js as a real subprocess via
+ * StdioClientTransport and drive all four MCP tools against a minimal fixture
+ * Playwright project at test/fixtures/pw-project/.
+ *
+ * Skipped automatically (with a console.warn) when the Playwright Chromium
+ * browser is not present in the local browser cache.
+ */
+
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
+import { existsSync, readdirSync } from 'fs';
+import { homedir } from 'os';
+import { join, resolve } from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = fileURLToPath(new URL('.', import.meta.url));
+const PW_PROJECT = resolve(__dirname, 'fixtures/pw-project');
+const DIST_INDEX = resolve(__dirname, '../dist/index.js');
+
+function fixtureInstalled(): boolean {
+  return existsSync(join(PW_PROJECT, 'node_modules', '.bin', 'playwright'));
+}
+
+function chromiumInstalled(): boolean {
+  const cacheDir =
+    process.env.PLAYWRIGHT_BROWSERS_PATH ?? join(homedir(), '.cache', 'ms-playwright');
+  try {
+    return readdirSync(cacheDir).some((e) => e.startsWith('chromium-'));
+  } catch {
+    return false;
+  }
+}
+
+const skipReasons: string[] = [];
+if (!fixtureInstalled())
+  skipReasons.push('fixture not installed — run: npm ci --prefix test/fixtures/pw-project');
+if (!chromiumInstalled())
+  skipReasons.push(
+    'Chromium not in Playwright cache — run: cd test/fixtures/pw-project && npx playwright install --with-deps chromium'
+  );
+
+const SKIP = skipReasons.length > 0;
+if (SKIP) {
+  console.warn('[e2e] e2e suite skipped:\n' + skipReasons.map((r) => `  • ${r}`).join('\n'));
+}
+
+type TextContent = { type: 'text'; text: string };
+
+let client: Client;
+
+function parseResult(result: Awaited<ReturnType<typeof client.callTool>>) {
+  expect(result.isError).toBeFalsy();
+  return JSON.parse((result.content as TextContent[])[0].text);
+}
+
+describe.skipIf(SKIP)('MCP server e2e — fixture Playwright project', () => {
+  beforeAll(async () => {
+    const env: Record<string, string> = {};
+    for (const [k, v] of Object.entries(process.env)) {
+      if (v !== undefined) env[k] = v;
+    }
+    env.PW_DIR = PW_PROJECT;
+
+    const transport = new StdioClientTransport({
+      command: 'node',
+      args: [DIST_INDEX],
+      env,
+    });
+    client = new Client({ name: 'e2e-client', version: '1.0.0' });
+    await client.connect(transport);
+  }, 30_000);
+
+  afterAll(async () => {
+    await client?.close();
+  });
+
+  // ── list_tests ────────────────────────────────────────────────────────────
+  // Uses `npx playwright test --list` — no browser run needed, so runs first.
+
+  describe('list_tests', () => {
+    it('returns all tests from the fixture project', async () => {
+      const data = parseResult(await client.callTool({ name: 'list_tests', arguments: {} }));
+      // fixture has 3 specs: homepage, smoke, failing
+      expect(data.count).toBeGreaterThanOrEqual(3);
+      expect(data.tests).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ title: expect.any(String), file: expect.any(String) }),
+        ])
+      );
+    });
+
+    it('@smoke tag filter reduces the result count', async () => {
+      const all = parseResult(await client.callTool({ name: 'list_tests', arguments: {} }));
+      const smoke = parseResult(
+        await client.callTool({ name: 'list_tests', arguments: { tag: '@smoke' } })
+      );
+      expect(smoke.count).toBeGreaterThan(0);
+      expect(smoke.count).toBeLessThan(all.count);
+      expect(smoke.tests.every((t: { tags: string[] }) => t.tags.includes('@smoke'))).toBe(true);
+    });
+  });
+
+  // ── run_tests / get_failed_tests / get_test_attachment ───────────────────
+  // One browser run populates results.json; the read-only tools then verify it.
+  // The timeout test comes LAST so it does not overwrite results.json before
+  // get_failed_tests and get_test_attachment have had a chance to read it.
+
+  describe('after a full browser test run', () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    let runData: any;
+
+    beforeAll(async () => {
+      runData = parseResult(await client.callTool({ name: 'run_tests', arguments: {} }));
+    }, 120_000);
+
+    describe('run_tests', () => {
+      it('returns structured stats', () => {
+        expect(runData.stats).toMatchObject({
+          expected: expect.any(Number),
+          unexpected: expect.any(Number),
+          skipped: expect.any(Number),
+          duration: expect.any(Number),
+        });
+      });
+
+      it('returns a test list that includes at least one failing spec', () => {
+        const failing = (runData.tests as Array<{ ok: boolean }>).filter((t) => !t.ok);
+        expect(failing.length).toBeGreaterThan(0);
+      });
+    });
+
+    describe('get_failed_tests', () => {
+      it('surfaces the deliberately failing spec', async () => {
+        const data = parseResult(
+          await client.callTool({ name: 'get_failed_tests', arguments: {} })
+        );
+        expect(data.failedCount).toBeGreaterThan(0);
+        const failing = (data.tests as Array<{ title: string }>).find((t) =>
+          t.title.includes('deliberately fails')
+        );
+        expect(failing).toBeDefined();
+      });
+    });
+
+    describe('get_test_attachment', () => {
+      it('reads the text file attached to the failing spec', async () => {
+        const data = parseResult(
+          await client.callTool({
+            name: 'get_test_attachment',
+            arguments: {
+              testTitle: 'deliberately fails with attachment',
+              attachmentName: 'error-details',
+            },
+          })
+        );
+        expect(data.content).toContain('deliberately fails');
+      });
+    });
+
+    // Runs AFTER get_failed_tests and get_test_attachment to avoid overwriting
+    // results.json while those tools still need to read it.
+    describe('run_tests timeout parameter', () => {
+      it('accepts the timeout parameter without error', async () => {
+        const data = parseResult(
+          await client.callTool({
+            name: 'run_tests',
+            arguments: { spec: 'tests/homepage.spec.ts', timeout: 120 },
+          })
+        );
+        expect(typeof data.exitCode).toBe('number');
+        expect(data.stats).toBeDefined();
+      }, 60_000);
+    });
+  });
+});

--- a/test/fixtures/pw-project/.gitignore
+++ b/test/fixtures/pw-project/.gitignore
@@ -1,0 +1,1 @@
+playwright-report/

--- a/test/fixtures/pw-project/package-lock.json
+++ b/test/fixtures/pw-project/package-lock.json
@@ -1,0 +1,78 @@
+{
+  "name": "pw-fixture",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "pw-fixture",
+      "version": "1.0.0",
+      "devDependencies": {
+        "@playwright/test": "1.56.1"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.56.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.56.1.tgz",
+      "integrity": "sha512-vSMYtL/zOcFpvJCW71Q/OEGQb7KYBPAdKh35WNSkaZA75JlAO8ED8UN6GUNTm3drWomcbcqRPFqQbLae8yBTdg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.56.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.56.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.56.1.tgz",
+      "integrity": "sha512-aFi5B0WovBHTEvpM3DzXTUaeN6eN0qWnTkKx4NQaH4Wvcmc153PdaY2UBdSYKaGYw+UyWXSVyxDUg5DoPEttjw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.56.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.56.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.56.1.tgz",
+      "integrity": "sha512-hutraynyn31F+Bifme+Ps9Vq59hKuUCz7H1kDOcBs+2oGguKkWTU50bBWrtz34OUWmIwpBTWDxaRPXrIXkgvmQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    }
+  }
+}

--- a/test/fixtures/pw-project/package.json
+++ b/test/fixtures/pw-project/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "pw-fixture",
+  "version": "1.0.0",
+  "private": true,
+  "devDependencies": {
+    "@playwright/test": "1.56.1"
+  }
+}

--- a/test/fixtures/pw-project/playwright.config.ts
+++ b/test/fixtures/pw-project/playwright.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './tests',
+  reporter: [['json', { outputFile: 'test-results/results.json' }]],
+  use: {
+    headless: true,
+    launchOptions: { args: ['--no-sandbox', '--disable-setuid-sandbox'] },
+  },
+  projects: [{ name: 'chromium', use: { browserName: 'chromium' } }],
+});

--- a/test/fixtures/pw-project/tests/failing.spec.ts
+++ b/test/fixtures/pw-project/tests/failing.spec.ts
@@ -1,0 +1,12 @@
+import { test, expect } from '@playwright/test';
+import { mkdirSync, writeFileSync } from 'fs';
+import { join } from 'path';
+
+test('deliberately fails with attachment', async ({ page }, testInfo) => {
+  await page.setContent('<p>test page</p>');
+  mkdirSync(testInfo.outputDir, { recursive: true });
+  const filePath = join(testInfo.outputDir, 'error-details.txt');
+  writeFileSync(filePath, 'This test deliberately fails for MCP e2e testing.\n');
+  await testInfo.attach('error-details', { path: filePath, contentType: 'text/plain' });
+  expect(1).toBe(2);
+});

--- a/test/fixtures/pw-project/tests/homepage.spec.ts
+++ b/test/fixtures/pw-project/tests/homepage.spec.ts
@@ -1,0 +1,6 @@
+import { test, expect } from '@playwright/test';
+
+test('homepage renders content', async ({ page }) => {
+  await page.setContent('<h1>Hello, World!</h1>');
+  await expect(page.locator('h1')).toHaveText('Hello, World!');
+});

--- a/test/fixtures/pw-project/tests/smoke.spec.ts
+++ b/test/fixtures/pw-project/tests/smoke.spec.ts
@@ -1,0 +1,6 @@
+import { test, expect } from '@playwright/test';
+
+test('smoke: button is visible', { tag: ['@smoke'] }, async ({ page }) => {
+  await page.setContent('<button>Click me</button>');
+  await expect(page.locator('button')).toBeVisible();
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -4,7 +4,7 @@ import { fileURLToPath } from 'url';
 export default defineConfig({
   test: {
     setupFiles: ['./test/setup.ts'],
-    exclude: [...configDefaults.exclude, '**/dist/**'],
+    exclude: [...configDefaults.exclude, '**/dist/**', 'test/e2e.test.ts', 'test/fixtures/pw-project/**'],
     env: {
       PW_DIR: fileURLToPath(new URL('./test/fixtures', import.meta.url)),
     },

--- a/vitest.e2e.config.ts
+++ b/vitest.e2e.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    include: ['test/e2e.test.ts'],
+    // Each e2e test can take up to 3 minutes (one full Playwright browser run)
+    testTimeout: 180_000,
+    hookTimeout: 60_000,
+    // Run in a forked process to avoid stdio interference with the MCP subprocess
+    pool: 'forks',
+  },
+});


### PR DESCRIPTION
## Summary

Closes #42.

- Adds a minimal Playwright fixture project at `test/fixtures/pw-project/` (3 spec files: one passing, one `@smoke`-tagged, one deliberately failing with a text attachment) pinned to `@playwright/test 1.56.1`.
- Adds `test/e2e.test.ts`: boots the built `dist/index.js` as a real subprocess via `StdioClientTransport` and asserts all four tools (`list_tests`, `run_tests`, `get_failed_tests`, `get_test_attachment`) against the fixture.
- Adds `npm run test:e2e` (isolated from `npm test`) and a matching `vitest.e2e.config.ts` with per-test timeout of 3 min and `pool: 'forks'` to prevent stdio interference.
- Adds `e2e` CI job with Playwright browser caching keyed on `test/fixtures/pw-project/package-lock.json`.

## Test plan

- [x] `npm test` (unit suite) still passes — 49 tests, sub-2 s
- [x] `npm run test:e2e` passes — 7 tests covering all four MCP tools, including the deliberate failure and its text attachment
- [x] Suite skips with a clear `console.warn` when Chromium or fixture dependencies are absent
- [x] `@smoke` tag filter reduces `list_tests` count from 3 to 1
- [x] `run_tests` with `timeout: 120` exercises the `#23` timeout parameter end-to-end

## Notes

- `test/fixtures/pw-project/node_modules/` and `test-results/` are gitignored; `package-lock.json` is committed.
- The timeout test runs **last** within the `after a full browser test run` describe block so it does not overwrite `results.json` before `get_failed_tests` and `get_test_attachment` read it.
- The unit test vitest config excludes `test/e2e.test.ts` and `test/fixtures/pw-project/**` so the fast path stays sub-second.

https://claude.ai/code/session_019Qs7SyFrBhSufcHWhEa7NQ