### PR TITLE
#35 ci: add MCP registry publish workflow

### DIFF
--- a/.github/workflows/publish-mcp.yml
+++ b/.github/workflows/publish-mcp.yml
@@ -1,0 +1,105 @@
+name: Publish to MCP registry
+
+on:
+  workflow_run:
+    workflows: ['Publish to npm']
+    types: [completed]
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  publish:
+    # Only run when the upstream npm-publish workflow succeeded AND was itself triggered
+    # by a release event — skips PR/push runs of the upstream workflow.
+    if: >-
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.event == 'release'
+    runs-on: ubuntu-latest
+    env:
+      MCP_REGISTRY_SEARCH_URL: https://registry.modelcontextprotocol.io/v0.1/servers
+    steps:
+      # workflow_run runs against the default branch by default, which may have drifted
+      # past the release commit. Pin checkout to the upstream workflow's commit SHA.
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
+
+      - name: Version-sync check
+        run: |
+          set -euo pipefail
+          node -e '
+          const pkg = require("./package.json");
+          const srv = require("./server.json");
+          const errs = [];
+          if (pkg.version !== srv.version) errs.push(`package.json.version (${pkg.version}) !== server.json.version (${srv.version})`);
+          if (pkg.version !== srv.packages[0].version) errs.push(`package.json.version (${pkg.version}) !== server.json.packages[0].version (${srv.packages[0].version})`);
+          if (pkg.mcpName !== srv.name) errs.push(`package.json.mcpName (${pkg.mcpName}) !== server.json.name (${srv.name})`);
+          if (errs.length) { console.error("Version sync check failed:\n  " + errs.join("\n  ")); process.exit(1); }
+          console.log(`Version sync check passed: ${pkg.version} / ${pkg.mcpName}`);
+          '
+
+      - id: meta
+        name: Read server metadata
+        run: |
+          set -euo pipefail
+          NAME=$(jq -er .name server.json)
+          VERSION=$(jq -er .version server.json)
+          echo "name=$NAME" >> "$GITHUB_OUTPUT"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Already-registered guard
+        env:
+          NAME: ${{ steps.meta.outputs.name }}
+          VERSION: ${{ steps.meta.outputs.version }}
+        run: |
+          set -euo pipefail
+          FOUND=$(curl -sSfL --get "${MCP_REGISTRY_SEARCH_URL}" --data-urlencode "search=$NAME" \
+            | jq -r --arg n "$NAME" --arg v "$VERSION" '[.servers[]? | select(.server.name == $n and .server.version == $v)] | length')
+          if [ "$FOUND" != "0" ]; then
+            echo "::error::Version ${VERSION} of ${NAME} is already listed in the MCP registry. Bump all three version fields in a single PR and cut a new release."
+            exit 1
+          fi
+          echo "Version ${VERSION} of ${NAME} is not yet on the MCP registry — proceeding."
+
+      - name: Install mcp-publisher (pinned, checksum-verified)
+        env:
+          MCP_PUBLISHER_TAG: v1.6.0
+          MCP_PUBLISHER_ASSET: mcp-publisher_linux_amd64.tar.gz
+          MCP_PUBLISHER_SHA256: 2de4ac3bf5b2aa9b012291a6969f16e4a2e37b70baab7f066e06998823405d42
+        run: |
+          set -euo pipefail
+          URL="https://github.com/modelcontextprotocol/registry/releases/download/${MCP_PUBLISHER_TAG}/${MCP_PUBLISHER_ASSET}"
+          curl -sSfL "$URL" -o /tmp/mcp-publisher.tar.gz
+          echo "${MCP_PUBLISHER_SHA256}  /tmp/mcp-publisher.tar.gz" | sha256sum -c -
+          mkdir -p "$HOME/.local/bin"
+          tar -xzf /tmp/mcp-publisher.tar.gz -C "$HOME/.local/bin" mcp-publisher
+          chmod +x "$HOME/.local/bin/mcp-publisher"
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+          "$HOME/.local/bin/mcp-publisher" --version
+
+      - name: Authenticate via GitHub OIDC
+        run: mcp-publisher login github-oidc
+
+      - name: Publish to MCP registry
+        run: mcp-publisher publish
+
+      - name: Post-publish smoke check
+        env:
+          NAME: ${{ steps.meta.outputs.name }}
+          VERSION: ${{ steps.meta.outputs.version }}
+        run: |
+          set -euo pipefail
+          for attempt in 1 2 3; do
+            FOUND=$(curl -sSfL --get "${MCP_REGISTRY_SEARCH_URL}" --data-urlencode "search=$NAME" \
+              | jq -r --arg n "$NAME" --arg v "$VERSION" '[.servers[]? | select(.server.name == $n and .server.version == $v)] | length')
+            if [ "$FOUND" != "0" ]; then
+              echo "Published ${NAME}@${VERSION} is visible in the registry (attempt ${attempt})."
+              exit 0
+            fi
+            echo "Attempt ${attempt}: ${NAME}@${VERSION} not yet visible; sleeping 5s."
+            sleep 5
+          done
+          echo "::error::Published but ${NAME}@${VERSION} not visible in the MCP registry search after 3 attempts."
+          exit 1

--- a/README.md
+++ b/README.md
@@ -358,13 +358,14 @@ Bug reports and pull requests are welcome. Please open an issue first for signif
 
 ## Release
 
-Releases are published to npm by [`.github/workflows/publish-npm.yml`](.github/workflows/publish-npm.yml) when a GitHub Release is marked **published**. Merging to `main` does not trigger a publish.
+Releases are published to npm by [`.github/workflows/publish-npm.yml`](.github/workflows/publish-npm.yml) and to the MCP registry by [`.github/workflows/publish-mcp.yml`](.github/workflows/publish-mcp.yml) when a GitHub Release is marked **published**. Merging to `main` does not trigger a publish.
 
 **Flow:**
 
 1. Open a bump PR that updates all three version fields: `package.json.version`, `server.json.version`, and `server.json.packages[0].version`. Merge it to `main`.
 2. Draft a GitHub Release pointing at the bump commit (tag `v<version>`), then publish the release.
-3. The workflow reads the version from `package.json`, verifies the three version fields match, confirms the version is not already on npm, runs `npm run build` and `npm test`, then publishes with `npm publish --access public --provenance`.
+3. `publish-npm.yml` reads the version from `package.json`, verifies the three version fields match, confirms the version is not already on npm, runs `npm run build` and `npm test`, then publishes with `npm publish --access public --provenance`.
+4. `publish-mcp.yml` chains off `publish-npm.yml` via `workflow_run`: once npm publish succeeds, it re-verifies the version fields, confirms the version is not already on the MCP registry, authenticates via GitHub OIDC, and publishes `server.json` to [registry.modelcontextprotocol.io](https://registry.modelcontextprotocol.io). No additional repository secret is required for MCP publishing — OIDC handles auth.
 
 **Required repository secret:**
 


### PR DESCRIPTION
Closes #35.

## Summary

Adds `.github/workflows/publish-mcp.yml` chained off #34's `publish-npm.yml` (merged in #48). After npm publish succeeds for a release, this workflow validates versions, installs a pinned `mcp-publisher`, authenticates via GitHub OIDC, publishes to the MCP registry, and smoke-verifies the listing.

## Design choices

- **`workflow_run` chaining** (not a shared `release` trigger) enforces npm-first ordering at the scheduler level, not in wall-clock hope.
- **Explicit `head_sha` checkout** avoids the `workflow_run`-defaults-to-main gotcha that would otherwise publish the wrong version.
- **Four-way version/name sync check** — mirrors `publish-npm.yml`'s guard, duplicated rather than extracted into a shared composite action per issue allowance.
- **Single `id: meta` step** reads `name` / `version` once via `jq -er` (exits non-zero on null/missing) and exposes them as step outputs — removes duplication and catches malformed `server.json` before any network call.
- **Already-registered guard** — MCP analog of `publish-npm.yml`'s `npm view` pre-publish guard (no `--dry-run` equivalent exists in `mcp-publisher`).
- **`curl --get --data-urlencode`** for registry search — correct URL encoding, not string interpolation.
- **Pinned `mcp-publisher v1.6.0` with SHA256 verification** — no `latest`, no unverified binaries.
- **GitHub OIDC auth** — no stored PAT, no device flow.
- **Smoke check with retry** — 3 attempts × 5s to handle eventual-consistency lag on the registry search index.

## Verification

- Version-sync snippet: simulated locally against current repo (passes at 1.0.4) and mutated copy (fails with clear message).
- Already-registered guard: simulated locally against `io.github.hubertgajewski/playwright-report-mcp@1.0.4` (correctly detects) and `@9.9.9` (correctly allows). Confirmed the registry response shape is `{servers: [{server: {name, version, ...}, _meta: {...}}, ...]}` — nested under `.server`.
- YAML syntax parsed cleanly.
- `mcp-publisher v1.6.0` Linux amd64 SHA256 pinned and verified against the release's `registry_1.6.0_checksums.txt`.
- Existing test suite still passes (49/49).
- End-to-end verification (acceptance criterion final bullet) requires cutting a real patch release — deferred, post-merge.

## Docs

Extends the existing `## Release` section in `README.md` (added by #48) with a step describing the MCP registry publish flow and noting that OIDC removes the need for a separate repository secret.

## Acceptance criteria

- [x] Workflow file exists at `.github/workflows/publish-mcp.yml`
- [x] Runs only after npm publish has succeeded for the same version (`workflow_run` + `conclusion=='success'` + `event=='release'`)
- [x] Does not modify `package.json` or `server.json` — read-only
- [x] Fails if the three version fields disagree
- [x] Fails if `package.json.mcpName` ≠ `server.json.name`
- [x] Uses GitHub OIDC (`mcp-publisher login github-oidc`), not a stored PAT
- [x] Pins `mcp-publisher` to `v1.6.0` with SHA256 checksum verification (not `latest`)
- [x] Post-publish smoke check against the registry search API
- [x] README documents the release flow
- [ ] End-to-end verified by cutting a real patch release — deferred, post-merge
