### PR TITLE
#54 chore: add prettier and reformat repo

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,7 +8,7 @@ updates:
     labels: [dependencies]
     groups:
       all:
-        patterns: ["*"]
+        patterns: ['*']
   - package-ecosystem: github-actions
     directory: /
     schedule:
@@ -17,4 +17,4 @@ updates:
     labels: [dependencies]
     groups:
       all:
-        patterns: ["*"]
+        patterns: ['*']

--- a/README.md
+++ b/README.md
@@ -35,14 +35,14 @@ An MCP (Model Context Protocol) server for running Playwright tests and reading 
 
 There are many Playwright MCP servers that control a browser — they navigate pages, click elements, fill forms, and take screenshots. Playwright Report MCP Server is not one of them.
 
-| | Browser automation MCPs | Playwright Report MCP Server |
-|---|---|---|
-| Examples | `microsoft/playwright-mcp`, `executeautomation/mcp-playwright` | this project |
-| Purpose | Let an AI agent drive a browser | Let an AI agent read test results |
-| Runs tests | No | Yes |
-| Returns pass/fail | No | Yes |
-| Surfaces error messages | No | Yes |
-| Reads attachment content | No | Yes |
+|                          | Browser automation MCPs                                        | Playwright Report MCP Server      |
+| ------------------------ | -------------------------------------------------------------- | --------------------------------- |
+| Examples                 | `microsoft/playwright-mcp`, `executeautomation/mcp-playwright` | this project                      |
+| Purpose                  | Let an AI agent drive a browser                                | Let an AI agent read test results |
+| Runs tests               | No                                                             | Yes                               |
+| Returns pass/fail        | No                                                             | Yes                               |
+| Surfaces error messages  | No                                                             | Yes                               |
+| Reads attachment content | No                                                             | Yes                               |
 
 ---
 
@@ -67,19 +67,20 @@ There are many Playwright MCP servers that control a browser — they navigate p
 
 > Approximate input token counts based on **Claude tokenization** (~3–4 characters per token for mixed JSON/text content).
 
-| What you need | Without MCP — approach | Tokens (no MCP) | With MCP — tool calls | Tokens (MCP) | Savings |
-|---|---|---|---|---|---|
-| Error message only — live run | `npx playwright test`, read stdout (`list`/`dot`) | ~500–1,200 | `run_tests` + `get_failed_tests` | ~300–500 | ~2× |
-| Error message only — existing results | Read full `results.json` | ~12,500–23,000 | `get_failed_tests` | ~300–500 | **~25–45×** |
-| + page state at failure | + read `error-context` file | ~15,000–26,000 | + `get_test_attachment('error-context')` | ~2,800–3,500 | **~4–7×** |
-| + custom text attachments¹ | + read attachment files | ~16,200–28,500 | + `get_test_attachment` ×2 | ~3,300–5,500 | **~4–5×** |
-| + full page HTML snapshot² | + read snapshot file | ~41,000–103,000 | + `get_test_attachment` | ~33,300–85,500 | ~1.2× |
+| What you need                         | Without MCP — approach                            | Tokens (no MCP) | With MCP — tool calls                    | Tokens (MCP)   | Savings     |
+| ------------------------------------- | ------------------------------------------------- | --------------- | ---------------------------------------- | -------------- | ----------- |
+| Error message only — live run         | `npx playwright test`, read stdout (`list`/`dot`) | ~500–1,200      | `run_tests` + `get_failed_tests`         | ~300–500       | ~2×         |
+| Error message only — existing results | Read full `results.json`                          | ~12,500–23,000  | `get_failed_tests`                       | ~300–500       | **~25–45×** |
+| + page state at failure               | + read `error-context` file                       | ~15,000–26,000  | + `get_test_attachment('error-context')` | ~2,800–3,500   | **~4–7×**   |
+| + custom text attachments¹            | + read attachment files                           | ~16,200–28,500  | + `get_test_attachment` ×2               | ~3,300–5,500   | **~4–5×**   |
+| + full page HTML snapshot²            | + read snapshot file                              | ~41,000–103,000 | + `get_test_attachment`                  | ~33,300–85,500 | ~1.2×       |
 
 > ¹ **Custom text attachments** — e.g. AI diagnosis (~500–2,000 tokens) and console logs (~200–500 tokens) added via `testInfo.attach()` in your own fixtures.
 >
 > ² **Full page HTML snapshot** — a custom fixture that attaches the full rendered page HTML on failure. Large pages alone can reach 30,000–80,000 tokens and dominate cost regardless of whether MCP is used.
 
 **Key observations:**
+
 - For a live run, stdout (`list`/`dot`) is compact but gives the agent no path to attachment content — dead end for deeper analysis
 - Reading `results.json` directly costs ~12,500–23,000 tokens even when only one test failed — most of it is passing test metadata the agent doesn't need
 - The biggest MCP gains are in the middle rows: getting error messages + page state from existing results at **~4–45× lower token cost**
@@ -159,11 +160,11 @@ Tested with **Claude Code (CLI)**. Should work with any MCP-compatible client th
 
 Runs the Playwright test suite and returns structured pass/fail results.
 
-| Input | Type | Description |
-|---|---|---|
-| `spec` | string (optional) | Spec file path relative to the project directory, e.g. `tests/login.spec.ts`. Must stay within the project directory. |
-| `browser` | enum (optional) | `Chromium`, `Firefox`, `Webkit`, `Mobile Chrome`, `Mobile Safari` |
-| `tag` | string (optional) | Tag filter, e.g. `@smoke` |
+| Input     | Type               | Description                                                                                                                     |
+| --------- | ------------------ | ------------------------------------------------------------------------------------------------------------------------------- |
+| `spec`    | string (optional)  | Spec file path relative to the project directory, e.g. `tests/login.spec.ts`. Must stay within the project directory.           |
+| `browser` | enum (optional)    | `Chromium`, `Firefox`, `Webkit`, `Mobile Chrome`, `Mobile Safari`                                                               |
+| `tag`     | string (optional)  | Tag filter, e.g. `@smoke`                                                                                                       |
 | `timeout` | integer (optional) | Timeout in seconds for the whole test run. Defaults to `300`. Use a larger value for long suites or a smaller one to fail fast. |
 
 Returns: exit code, run stats, and a summary of all tests with status, duration, and error per project.
@@ -178,9 +179,9 @@ Returns: failed test count, titles, file paths, per-project status, error messag
 
 Reads the content of a named text attachment for a specific test from the last run.
 
-| Input | Type | Description |
-|---|---|---|
-| `testTitle` | string | Exact test title as shown in the report |
+| Input            | Type   | Description                                                        |
+| ---------------- | ------ | ------------------------------------------------------------------ |
+| `testTitle`      | string | Exact test title as shown in the report                            |
 | `attachmentName` | string | Attachment name, e.g. `error-context`, `ai-diagnosis`, `page-html` |
 
 Returns: the attachment content as text. Binary attachments and files over 1 MB are rejected with an error.
@@ -189,8 +190,8 @@ Returns: the attachment content as text. Binary attachments and files over 1 MB 
 
 Lists all tests with their spec file and tags without running them.
 
-| Input | Type | Description |
-|---|---|---|
+| Input | Type              | Description                  |
+| ----- | ----------------- | ---------------------------- |
 | `tag` | string (optional) | Filter by tag, e.g. `@smoke` |
 
 ---
@@ -199,12 +200,12 @@ Lists all tests with their spec file and tags without running them.
 
 Playwright attaches files to failed tests automatically. `get_test_attachment` can read any text attachment by name.
 
-| Attachment name | Source | Present in every project |
-|---|---|---|
-| `error-context` | Playwright built-in — YAML accessibility tree snapshot at the point of failure | Yes |
-| `screenshot` | Playwright built-in — PNG screenshot (binary, not readable) | Yes |
-| `video` | Playwright built-in — WebM video (binary, not readable) | Yes |
-| Custom attachments | Added via `testInfo.attach()` in your fixtures | Depends on project |
+| Attachment name    | Source                                                                         | Present in every project |
+| ------------------ | ------------------------------------------------------------------------------ | ------------------------ |
+| `error-context`    | Playwright built-in — YAML accessibility tree snapshot at the point of failure | Yes                      |
+| `screenshot`       | Playwright built-in — PNG screenshot (binary, not readable)                    | Yes                      |
+| `video`            | Playwright built-in — WebM video (binary, not readable)                        | Yes                      |
+| Custom attachments | Added via `testInfo.attach()` in your fixtures                                 | Depends on project       |
 
 The `error-context` attachment is the most useful for projects without custom fixtures — it gives a semantic, structured view of the page at the moment of failure with no setup required.
 
@@ -243,10 +244,10 @@ Add to your `.mcp.json` at the root of your project:
 
 ### Environment variables
 
-| Variable | Default | Description |
-|---|---|---|
-| `PW_DIR` | `process.cwd()` | Root of the Playwright project — used as the working directory when running tests |
-| `PW_RESULTS_FILE` | `<PW_DIR>/test-results/results.json` | Absolute path to the JSON reporter output file |
+| Variable          | Default                              | Description                                                                       |
+| ----------------- | ------------------------------------ | --------------------------------------------------------------------------------- |
+| `PW_DIR`          | `process.cwd()`                      | Root of the Playwright project — used as the working directory when running tests |
+| `PW_RESULTS_FILE` | `<PW_DIR>/test-results/results.json` | Absolute path to the JSON reporter output file                                    |
 
 Set `PW_RESULTS_FILE` if your `playwright.config.ts` writes the report to a non-default location.
 
@@ -369,8 +370,8 @@ Releases are published to npm by [`.github/workflows/publish-npm.yml`](.github/w
 
 **Required repository secret:**
 
-| Name | How to create | Scope |
-|---|---|---|
+| Name        | How to create                                                                                            | Scope                                               |
+| ----------- | -------------------------------------------------------------------------------------------------------- | --------------------------------------------------- |
 | `NPM_TOKEN` | [npmjs.com → Access Tokens → Generate New Token → "Automation"](https://www.npmjs.com/settings/~/tokens) | Write access to the `playwright-report-mcp` package |
 
 **Recovery from a failed publish:** npm refuses to republish an existing version and restricts unpublishing after 72 hours. If a publish fails for any reason, bump to the next patch version in a new PR and cut a new release — do not try to re-run the failed release.
@@ -378,4 +379,3 @@ Releases are published to npm by [`.github/workflows/publish-npm.yml`](.github/w
 ## License
 
 [MIT](LICENSE) — Copyright (c) [Hubert Gajewski](https://hubertgajewski.com)
-

--- a/index.ts
+++ b/index.ts
@@ -8,7 +8,9 @@ import { fileURLToPath } from 'url';
 import { z } from 'zod';
 
 const PW_DIR = resolve(process.env.PW_DIR ?? process.cwd());
-const RESULTS_FILE = resolve(process.env.PW_RESULTS_FILE ?? join(PW_DIR, 'test-results', 'results.json'));
+const RESULTS_FILE = resolve(
+  process.env.PW_RESULTS_FILE ?? join(PW_DIR, 'test-results', 'results.json')
+);
 
 // ---------- types (subset of Playwright JSON reporter output) ----------
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,11 +18,12 @@
       "devDependencies": {
         "@types/node": "^25.5.0",
         "@vitest/coverage-v8": "^4.1.4",
+        "prettier": "^3",
         "typescript": "^6.0.2",
         "vitest": "^4.1.1"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       }
     },
     "node_modules/@babel/helper-string-parser": {
@@ -1999,6 +2000,22 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.8.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.2.tgz",
+      "integrity": "sha512-8c3mgTe0ASwWAJK+78dpviD+A8EqhndQPUBpNUIPt6+xWlIigCwfN01lWr9MAede4uqXGTEKeQWTvzb3vjia0Q==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/proxy-addr": {

--- a/package.json
+++ b/package.json
@@ -35,7 +35,9 @@
     "start": "node dist/index.js",
     "test": "vitest run",
     "test:e2e": "npm ci --prefix test/fixtures/pw-project && vitest run --config vitest.e2e.config.ts",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "format": "prettier --write \"**/*.{ts,js,json,md,yml,yaml}\" --ignore-path .gitignore",
+    "format:check": "prettier --check \"**/*.{ts,js,json,md,yml,yaml}\" --ignore-path .gitignore"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.12.0",
@@ -44,6 +46,7 @@
   "devDependencies": {
     "@types/node": "^25.5.0",
     "@vitest/coverage-v8": "^4.1.4",
+    "prettier": "^3",
     "typescript": "^6.0.2",
     "vitest": "^4.1.1"
   }

--- a/test/e2e.test.ts
+++ b/test/e2e.test.ts
@@ -34,8 +34,7 @@ function chromiumInstalled(): boolean {
 }
 
 const skipReasons: string[] = [];
-if (!existsSync(DIST_INDEX))
-  skipReasons.push('server not built — run: npm run build');
+if (!existsSync(DIST_INDEX)) skipReasons.push('server not built — run: npm run build');
 if (!fixtureInstalled())
   skipReasons.push('fixture not installed — run: npm ci --prefix test/fixtures/pw-project');
 if (!chromiumInstalled())

--- a/test/server.test.ts
+++ b/test/server.test.ts
@@ -219,9 +219,7 @@ describe('parseListJson — tag extraction', () => {
       ],
     });
     const tests = parseListJson(input);
-    expect(tests).toEqual([
-      { title: 'menu opens', file: 'tests/nav.spec.ts', tags: ['@smoke'] },
-    ]);
+    expect(tests).toEqual([{ title: 'menu opens', file: 'tests/nav.spec.ts', tags: ['@smoke'] }]);
   });
 
   it('returns an empty tags array when a spec has no tags', () => {
@@ -337,13 +335,7 @@ describe('parseListJson — tag extraction', () => {
 
 describe('buildListTestsCmd', () => {
   it('requests the JSON reporter with --list', () => {
-    expect(buildListTestsCmd()).toEqual([
-      'npx',
-      'playwright',
-      'test',
-      '--list',
-      '--reporter=json',
-    ]);
+    expect(buildListTestsCmd()).toEqual(['npx', 'playwright', 'test', '--list', '--reporter=json']);
   });
 
   it('appends --grep when a tag is provided', () => {
@@ -399,9 +391,7 @@ describe('run_tests — happy-path summarization', () => {
     const data = parseResult(await client.callTool({ name: 'run_tests', arguments: {} }));
     expect(data.stats).toEqual(stats);
     expect(data.tests).toHaveLength(2);
-    const byTitle = Object.fromEntries(
-      data.tests.map((t: { title: string }) => [t.title, t])
-    );
+    const byTitle = Object.fromEntries(data.tests.map((t: { title: string }) => [t.title, t]));
     expect(byTitle['login succeeds'].ok).toBe(true);
     expect(byTitle['login succeeds'].results[0]).toMatchObject({
       project: 'Chromium',
@@ -510,9 +500,7 @@ describe('get_test_attachment — error gates', () => {
                     {
                       status: 'failed',
                       duration: 10,
-                      attachments: [
-                        { name: 'diag', contentType: 'text/plain', path: bigPath },
-                      ],
+                      attachments: [{ name: 'diag', contentType: 'text/plain', path: bigPath }],
                     },
                   ],
                 },

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -14,7 +14,4 @@ writeFileSync(attachmentPath, attachmentContent);
 const failedResult = suites[0].specs[1].tests[0].results[0];
 failedResult.attachments = [{ name: 'diagnosis', contentType: 'text/plain', path: attachmentPath }];
 
-writeFileSync(
-  join(resultsDir, 'results.json'),
-  JSON.stringify({ suites, stats }, null, 2)
-);
+writeFileSync(join(resultsDir, 'results.json'), JSON.stringify({ suites, stats }, null, 2));

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -4,7 +4,12 @@ import { fileURLToPath } from 'url';
 export default defineConfig({
   test: {
     setupFiles: ['./test/setup.ts'],
-    exclude: [...configDefaults.exclude, '**/dist/**', 'test/e2e.test.ts', 'test/fixtures/pw-project/**'],
+    exclude: [
+      ...configDefaults.exclude,
+      '**/dist/**',
+      'test/e2e.test.ts',
+      'test/fixtures/pw-project/**',
+    ],
     env: {
       PW_DIR: fileURLToPath(new URL('./test/fixtures', import.meta.url)),
     },


### PR DESCRIPTION
Closes #54.

Part 1 of 2 for #54 — CI enforcement lands in the stacked follow-up #56. (Merging this will auto-close #54; reopen if you want to keep tracking until #56 merges.)

## Summary

- Install `prettier@^3` (matches the major used in `orwellstat/playwright/typescript`) and add `format` / `format:check` npm scripts using the exact glob from issue #54.
- One-shot reformat of the 7 drifted files in the repo today — all changes are whitespace, line-wrapping, and quote-style; no behavioural edits.

## What moved

- `package.json`: `prettier` devDep + `format` / `format:check` scripts.
- Reformatted: `.github/dependabot.yml`, `README.md`, `index.ts`, `test/e2e.test.ts`, `test/server.test.ts`, `test/setup.ts`, `vitest.config.ts`.

The issue listed 8 files; today only 7 drift — `CLAUDE.md` is already Prettier-clean and wasn't touched.

## Notes

The issue also asked to update `CLAUDE.md` to replace *"Formatting is not enforced in CI."* — but `CLAUDE.md` is not tracked in this repo (it only exists as an untracked file locally). Nothing to update in the committed tree. If/when `CLAUDE.md` gets committed, the wording change can go with that.

## Test plan

- [x] `npm ci` succeeds
- [x] `npm run build` succeeds
- [x] `npm test` — 49/49 passing
- [x] `npm run format:check` — clean
- [x] Reviewed each reformat diff with `git diff -w` — no semantic changes
