### PR TITLE
#54 ci: enforce prettier format:check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,9 @@ jobs:
           node-version: ${{ matrix.node-version }}
           cache: 'npm'
       - run: npm ci
+      - name: Check formatting
+        if: matrix.node-version == '22'
+        run: npm run format:check
       - run: npm run build
       - run: npm test
       - name: Run coverage


### PR DESCRIPTION
Closes #54.

Part 2 of 2 for #54. **Stacked on #55** — needs that to land first (or this PR's base switched to `main` after #55 merges) because without #55 there is no `format:check` script and prettier is not in `devDependencies`.

## Summary

- Add a `Check formatting` step to `.github/workflows/ci.yml` between `npm ci` and `npm run build` that runs `npm run format:check`.
- Gated with `if: matrix.node-version == '22'` so the check runs once per CI invocation — formatting isn't Node-version dependent, no point paying for it twice in the matrix.

## Why

Now that `format:check` is a script (#55), wiring it into CI makes `prettier --check` the canary for future drift — which is the whole point of adding the tooling.

## Test plan

- [x] Confirmed `format:check` exits 0 on the clean repo
- [x] Confirmed `format:check` exits 1 when a deliberately malformed `.ts` file is dropped into the tree
- [x] CI: `test (22)` shows the new `Check formatting` step green; `test (20)` skips it (no-op)
- [x] CI: overall job green
