### PR TITLE
#50 ci: SHA-pin davelosert/vitest-coverage-report-action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
         run: npx vitest run --coverage
       - name: Report coverage on PR
         if: matrix.node-version == '22' && github.event_name == 'pull_request'
-        uses: davelosert/vitest-coverage-report-action@v2
+        uses: davelosert/vitest-coverage-report-action@3c50566c523e04813df28de8f7c48dd97d663f1c # v2.11.2
       - name: Upload coverage artifact
         if: matrix.node-version == '22'
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
Closes #50

## Summary
- Replace `davelosert/vitest-coverage-report-action@v2` with a full-length commit SHA pin (`3c50566c523e04813df28de8f7c48dd97d663f1c`, v2.11.2) so a retag of the third-party action cannot silently run on PRs with `pull-requests: write`.
- No behavioural change — same action, same inputs, same `if` guard.

## Test plan
- [x] CI passes on this PR (the action itself runs on PRs, so a green run validates the SHA resolves and the action still executes).
