### PR TITLE
#51 chore: drop redundant exclude from tsconfig.json

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,6 +8,5 @@
     "strict": true,
     "types": ["node"]
   },
-  "include": ["index.ts"],
-  "exclude": ["test", "vitest.config.ts"]
+  "include": ["index.ts"]
 }


### PR DESCRIPTION
Closes #51

## Summary
- Remove the redundant `exclude` entry from `tsconfig.json`. `include` already whitelists exactly one file (`index.ts`), so `exclude: ["test", "vitest.config.ts"]` has no effect — leftover cruft that could mislead future contributors into thinking the excludes are load-bearing.

## Test plan
- [x] `npm run build` produces a byte-identical `dist/index.js` before and after the change (verified via `diff`).
- [x] `npm test` — all 49 tests pass.
