### PR TITLE
#52 feat: surface timeout explicitly in run_tests result

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,12 +160,12 @@ Tested with **Claude Code (CLI)**. Should work with any MCP-compatible client th
 
 Runs the Playwright test suite and returns structured pass/fail results.
 
-| Input     | Type               | Description                                                                                                                     |
-| --------- | ------------------ | ------------------------------------------------------------------------------------------------------------------------------- |
-| `spec`    | string (optional)  | Spec file path relative to the project directory, e.g. `tests/login.spec.ts`. Must stay within the project directory.           |
-| `browser` | enum (optional)    | `Chromium`, `Firefox`, `Webkit`, `Mobile Chrome`, `Mobile Safari`                                                               |
-| `tag`     | string (optional)  | Tag filter, e.g. `@smoke`                                                                                                       |
-| `timeout` | integer (optional) | Timeout in seconds for the whole test run. Defaults to `300`. Use a larger value for long suites or a smaller one to fail fast. |
+| Input     | Type               | Description                                                                                                                                                                                                                                                     |
+| --------- | ------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `spec`    | string (optional)  | Spec file path relative to the project directory, e.g. `tests/login.spec.ts`. Must stay within the project directory.                                                                                                                                           |
+| `browser` | enum (optional)    | `Chromium`, `Firefox`, `Webkit`, `Mobile Chrome`, `Mobile Safari`                                                                                                                                                                                               |
+| `tag`     | string (optional)  | Tag filter, e.g. `@smoke`                                                                                                                                                                                                                                       |
+| `timeout` | integer (optional) | Timeout in milliseconds for the whole test run. Defaults to `300000` (5 min). Use a larger value for long suites or a smaller one to fail fast. When the run is killed by this timeout, the tool returns an explicit error rather than a generic non-zero exit. |
 
 Returns: exit code, run stats, and a summary of all tests with status, duration, and error per project.
 

--- a/index.ts
+++ b/index.ts
@@ -178,7 +178,7 @@ server.registerTool(
         .int()
         .positive()
         .optional()
-        .describe('Timeout in seconds for the whole test run. Defaults to 300.'),
+        .describe('Timeout in milliseconds for the whole test run. Defaults to 300000.'),
     },
   },
   async ({ spec, browser, tag, timeout }) => {
@@ -192,9 +192,12 @@ server.registerTool(
     if (browser) cmd.push('--project', browser);
     if (tag) cmd.push('--grep', tag);
 
-    const result = runPlaywright(cmd, timeout ? timeout * 1000 : 300_000);
+    const result = runPlaywright(cmd, timeout ?? 300_000);
 
     if (result.error) return err(`Failed to spawn Playwright: ${result.error.message}`);
+
+    if (timeout !== undefined && result.signal === 'SIGTERM')
+      return err(`Playwright test run exceeded the ${timeout}ms timeout and was killed.`);
 
     const report = readLastReport();
     if (!report)

--- a/test/e2e.test.ts
+++ b/test/e2e.test.ts
@@ -163,7 +163,7 @@ describe.skipIf(SKIP)('MCP server e2e — fixture Playwright project', () => {
         const data = parseResult(
           await client.callTool({
             name: 'run_tests',
-            arguments: { spec: 'tests/homepage.spec.ts', timeout: 120 },
+            arguments: { spec: 'tests/homepage.spec.ts', timeout: 120_000 },
           })
         );
         expect(typeof data.exitCode).toBe('number');

--- a/test/server.test.ts
+++ b/test/server.test.ts
@@ -125,14 +125,14 @@ describe('run_tests — spec path validation', () => {
 describe('run_tests — timeout', () => {
   beforeEach(() => spawnSyncMock.mockClear());
 
-  it('defaults to 300 seconds when timeout is omitted', async () => {
+  it('defaults to 300000 ms when timeout is omitted', async () => {
     await client.callTool({ name: 'run_tests', arguments: {} });
     expect(spawnSyncMock).toHaveBeenCalledTimes(1);
     expect(spawnSyncMock.mock.calls[0][2]).toMatchObject({ timeout: 300_000 });
   });
 
-  it('passes the custom timeout to spawnSync in milliseconds', async () => {
-    await client.callTool({ name: 'run_tests', arguments: { timeout: 60 } });
+  it('passes the custom timeout through to spawnSync verbatim (milliseconds)', async () => {
+    await client.callTool({ name: 'run_tests', arguments: { timeout: 60_000 } });
     expect(spawnSyncMock).toHaveBeenCalledTimes(1);
     expect(spawnSyncMock.mock.calls[0][2]).toMatchObject({ timeout: 60_000 });
   });
@@ -140,6 +140,17 @@ describe('run_tests — timeout', () => {
   it('rejects non-positive timeout values', async () => {
     const result = await client.callTool({ name: 'run_tests', arguments: { timeout: 0 } });
     expect(result.isError).toBe(true);
+  });
+
+  it('surfaces an explicit error when SIGTERM follows a caller-specified timeout', async () => {
+    spawnSyncMock.mockReturnValueOnce({ status: null, signal: 'SIGTERM', stdout: '', stderr: '' });
+    const result = await client.callTool({
+      name: 'run_tests',
+      arguments: { timeout: 1000 },
+    });
+    expect(result.isError).toBe(true);
+    const text = (result.content as TextContent[])[0].text;
+    expect(text).toContain('exceeded the 1000ms timeout');
   });
 });
 

--- a/test/server.test.ts
+++ b/test/server.test.ts
@@ -152,6 +152,15 @@ describe('run_tests — timeout', () => {
     const text = (result.content as TextContent[])[0].text;
     expect(text).toContain('exceeded the 1000ms timeout');
   });
+
+  // Canary: protects the `timeout !== undefined` half of the SIGTERM guard —
+  // without a caller-supplied timeout, SIGTERM must fall through to the normal report-read path.
+  it('does not treat SIGTERM as a timeout error when no timeout was specified', async () => {
+    spawnSyncMock.mockReturnValueOnce({ status: null, signal: 'SIGTERM', stdout: '', stderr: '' });
+    const data = parseResult(await client.callTool({ name: 'run_tests', arguments: {} }));
+    expect(data.exitCode).toBe(-1);
+    expect(data.stats).toEqual(stats);
+  });
 });
 
 describe('parseListJson — tag extraction', () => {


### PR DESCRIPTION
Closes #52

## ⚠️ Breaking change

The `run_tests` `timeout` parameter now takes **milliseconds** instead of seconds. Any client passing `timeout: 60` meaning "60 seconds" will, after this change, kill Playwright after 60ms. Warrants a major-version bump at release time. (Note: a separate in-flight PR for #53 is already cutting 2.0.0 for the Node 20 → 22 drop — both breaking changes can land together under that major.)

## Summary

- `run_tests` now takes `timeout` in **milliseconds** to match `spawnSync`'s native unit; drops the `* 1000` conversion and updates the Zod `.describe()` text and the README entry.
- When `spawnSync` is killed by its own timeout (`signal === 'SIGTERM'`) **and** a `timeout` was supplied, the handler returns an explicit error (`ERROR: Playwright test run exceeded the <n>ms timeout and was killed.`) via the existing `err()` helper. Without a caller-supplied `timeout`, SIGTERM from an external kill still falls through to the normal path — unchanged.
- Updates the existing `run_tests — timeout` test to reflect the new ms semantics and adds two new tests: the timeout-error path, and a canary for the no-caller-timeout fallthrough.
- Updates the e2e test's `timeout: 120` → `timeout: 120_000` to match the new unit.

## Test plan

- [x] `npm test` — all 51 tests pass (49 prior + 2 new)
- [x] `npm run build` — clean `tsc`
- [x] `npm run format:check` — passes
- [x] CI e2e job passes on the updated `timeout: 120_000`
