### PR TITLE
#53 chore: bump Node floor to >=22 and release 2.0.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: ['20', '22']
+        node-version: ['22', '24']
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -15,7 +15,7 @@ jobs:
 
       - uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '24'
           registry-url: 'https://registry.npmjs.org'
           cache: 'npm'
 
@@ -51,9 +51,9 @@ jobs:
 
       - run: npm test
 
-      # TODO: migrate to npm Trusted Publishing (OIDC) — drop NODE_AUTH_TOKEN,
-      # pin Node to >= 22 so the npm CLI supports it, and configure the trusted
-      # publisher on npmjs.com. See https://docs.npmjs.com/trusted-publishers
+      # TODO: migrate to npm Trusted Publishing (OIDC) — drop NODE_AUTH_TOKEN
+      # once the trusted publisher is configured on npmjs.com against this repo
+      # and workflow. See https://docs.npmjs.com/trusted-publishers
       - run: npm publish --access public --provenance
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 An MCP (Model Context Protocol) server for running Playwright tests and reading structured results, failed test details, and attachment content — designed for AI agents doing test failure analysis.
 
 ![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)
-![Node.js: 20+](https://img.shields.io/badge/node-%3E%3D20-brightgreen.svg)
+![Node.js: 22+](https://img.shields.io/badge/node-%3E%3D22-brightgreen.svg)
 
 ---
 
@@ -278,7 +278,7 @@ Use `PW_DIR` to point the server at any Playwright project directory. Register a
 
 ## Requirements
 
-- Node.js 20+
+- Node.js 22+
 - `@playwright/test` 1.40 or later
 - JSON reporter configured in your Playwright project
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "playwright-report-mcp",
-  "version": "1.0.4",
+  "version": "2.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "playwright-report-mcp",
-      "version": "1.0.4",
+      "version": "2.0.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.0",
@@ -16,14 +16,14 @@
         "playwright-report-mcp": "dist/index.js"
       },
       "devDependencies": {
-        "@types/node": "^25.5.0",
+        "@types/node": "^22",
         "@vitest/coverage-v8": "^4.1.4",
         "prettier": "^3",
         "typescript": "^6.0.2",
         "vitest": "^4.1.1"
       },
       "engines": {
-        "node": ">=20"
+        "node": ">=22"
       }
     },
     "node_modules/@babel/helper-string-parser": {
@@ -537,13 +537,13 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "25.6.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
-      "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
+      "version": "22.19.17",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.17.tgz",
+      "integrity": "sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~7.19.0"
+        "undici-types": "~6.21.0"
       }
     },
     "node_modules/@vitest/coverage-v8": {
@@ -2435,9 +2435,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "7.19.2",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
-      "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "playwright-report-mcp",
-  "version": "1.0.4",
+  "version": "2.0.0",
   "mcpName": "io.github.hubertgajewski/playwright-report-mcp",
   "description": "MCP server for running Playwright tests and reading structured results — designed for AI agents doing test failure analysis",
   "type": "module",
@@ -10,7 +10,7 @@
     "dist/index.js"
   ],
   "engines": {
-    "node": ">=20"
+    "node": ">=22"
   },
   "keywords": [
     "playwright",
@@ -44,7 +44,7 @@
     "zod": "^4.0.0"
   },
   "devDependencies": {
-    "@types/node": "^25.5.0",
+    "@types/node": "^22",
     "@vitest/coverage-v8": "^4.1.4",
     "prettier": "^3",
     "typescript": "^6.0.2",

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/hubertgajewski/playwright-report-mcp",
     "source": "github"
   },
-  "version": "1.0.4",
+  "version": "2.0.0",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "playwright-report-mcp",
-      "version": "1.0.4",
+      "version": "2.0.0",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
## Summary

- Bump Node floor from `>=20` to `>=22`, align `@types/node` to `^22`, and release as `2.0.0` (SemVer-breaking drop of Node 20).
- CI matrix moves to `['22', '24']` (the current LTS); coverage-report gating stays on `'22'`.
- Publish workflow pins Node to `24`; the TODO is retained for the remaining npmjs.com-side Trusted Publishing migration.

## Not in this PR

Removing `NODE_AUTH_TOKEN` / `NPM_TOKEN` in favour of npm Trusted Publishing is deferred — per the issue's own split-PR note, it requires configuring the trusted publisher on npmjs.com against this repo/workflow, which is not something this PR can do. Everything else needed for 2.0.0 ships here.

## Test plan

- [x] `npm install` regenerates `package-lock.json` cleanly (no audit findings)
- [x] `npm run build` — TypeScript compiles with `@types/node@^22`
- [x] `npm test` — all 49 tests pass
- [x] `npm run format:check` — Prettier clean
- [x] Version sync check across `package.json` / `server.json` / `server.json.packages[0]` — all at `2.0.0`
- [x] CI proves the suite on Node 22 and Node 24

Closes #53
