### PR TITLE
#64 fix: route spawnSync ETIMEDOUT to the friendly timeout error

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -322,8 +322,12 @@ server.registerTool(
     const result = runPlaywright(buildListTestsCmd(tag), listTimeout);
 
     if (result.error) {
-      if ((result.error as NodeJS.ErrnoException).code === 'ETIMEDOUT')
-        return err(`Playwright list_tests exceeded the ${listTimeout}ms timeout and was killed.`);
+      // Node's spawnSync({ timeout }) populates BOTH error.code='ETIMEDOUT' and signal='SIGTERM'
+      // when the timer fires, so this check must precede the generic spawn-failure branch.
+      if ('code' in result.error && result.error.code === 'ETIMEDOUT')
+        return err(
+          `Listing Playwright tests exceeded the ${listTimeout}ms timeout and was killed.`
+        );
       return err(`Failed to spawn Playwright: ${result.error.message}`);
     }
 

--- a/index.ts
+++ b/index.ts
@@ -192,12 +192,16 @@ server.registerTool(
     if (browser) cmd.push('--project', browser);
     if (tag) cmd.push('--grep', tag);
 
-    const result = runPlaywright(cmd, timeout ?? 300_000);
+    const effectiveTimeout = timeout ?? 300_000;
+    const result = runPlaywright(cmd, effectiveTimeout);
 
-    if (result.error) return err(`Failed to spawn Playwright: ${result.error.message}`);
-
-    if (timeout !== undefined && result.signal === 'SIGTERM')
-      return err(`Playwright test run exceeded the ${timeout}ms timeout and was killed.`);
+    if (result.error) {
+      if ((result.error as NodeJS.ErrnoException).code === 'ETIMEDOUT')
+        return err(
+          `Playwright test run exceeded the ${effectiveTimeout}ms timeout and was killed.`
+        );
+      return err(`Failed to spawn Playwright: ${result.error.message}`);
+    }
 
     const report = readLastReport();
     if (!report)

--- a/index.ts
+++ b/index.ts
@@ -196,7 +196,9 @@ server.registerTool(
     const result = runPlaywright(cmd, effectiveTimeout);
 
     if (result.error) {
-      if ((result.error as NodeJS.ErrnoException).code === 'ETIMEDOUT')
+      // Node's spawnSync({ timeout }) populates BOTH error.code='ETIMEDOUT' and signal='SIGTERM'
+      // when the timer fires, so this check must precede the generic spawn-failure branch.
+      if ('code' in result.error && result.error.code === 'ETIMEDOUT')
         return err(
           `Playwright test run exceeded the ${effectiveTimeout}ms timeout and was killed.`
         );

--- a/index.ts
+++ b/index.ts
@@ -318,9 +318,14 @@ server.registerTool(
     },
   },
   async ({ tag }) => {
-    const result = runPlaywright(buildListTestsCmd(tag), 30_000);
+    const listTimeout = 30_000;
+    const result = runPlaywright(buildListTestsCmd(tag), listTimeout);
 
-    if (result.error) return err(`Failed to spawn Playwright: ${result.error.message}`);
+    if (result.error) {
+      if ((result.error as NodeJS.ErrnoException).code === 'ETIMEDOUT')
+        return err(`Playwright list_tests exceeded the ${listTimeout}ms timeout and was killed.`);
+      return err(`Failed to spawn Playwright: ${result.error.message}`);
+    }
 
     const stdout = result.stdout ?? '';
     let tests: Array<{ title: string; file: string; tags: string[] }>;

--- a/test/server.test.ts
+++ b/test/server.test.ts
@@ -784,6 +784,22 @@ describe('list_tests — via MCP client', () => {
     expect((result.content as TextContent[])[0].text).toContain('Failed to spawn Playwright');
   });
 
+  it('surfaces an explicit error when spawnSync times out under the 30s list_tests cap', async () => {
+    const timeoutError = Object.assign(new Error('spawnSync npx ETIMEDOUT'), { code: 'ETIMEDOUT' });
+    spawnSyncMock.mockReturnValueOnce({
+      status: null,
+      signal: 'SIGTERM',
+      error: timeoutError,
+      stdout: '',
+      stderr: '',
+    });
+    const result = await client.callTool({ name: 'list_tests', arguments: {} });
+    expect(result.isError).toBe(true);
+    const text = (result.content as TextContent[])[0].text;
+    expect(text).toContain('exceeded the 30000ms timeout');
+    expect(text).not.toContain('Failed to spawn');
+  });
+
   it('returns error when --list output cannot be parsed as JSON', async () => {
     spawnSyncMock.mockReturnValueOnce({
       status: 0,

--- a/test/server.test.ts
+++ b/test/server.test.ts
@@ -142,8 +142,17 @@ describe('run_tests — timeout', () => {
     expect(result.isError).toBe(true);
   });
 
-  it('surfaces an explicit error when SIGTERM follows a caller-specified timeout', async () => {
-    spawnSyncMock.mockReturnValueOnce({ status: null, signal: 'SIGTERM', stdout: '', stderr: '' });
+  it('surfaces an explicit error when spawnSync times out under a caller-specified timeout', async () => {
+    // Node's spawnSync({ timeout }) populates BOTH error.code='ETIMEDOUT' and signal='SIGTERM'
+    // when the timer fires; the error branch runs first, so assert on that path.
+    const timeoutError = Object.assign(new Error('spawnSync npx ETIMEDOUT'), { code: 'ETIMEDOUT' });
+    spawnSyncMock.mockReturnValueOnce({
+      status: null,
+      signal: 'SIGTERM',
+      error: timeoutError,
+      stdout: '',
+      stderr: '',
+    });
     const result = await client.callTool({
       name: 'run_tests',
       arguments: { timeout: 1000 },
@@ -151,15 +160,22 @@ describe('run_tests — timeout', () => {
     expect(result.isError).toBe(true);
     const text = (result.content as TextContent[])[0].text;
     expect(text).toContain('exceeded the 1000ms timeout');
+    expect(text).not.toContain('Failed to spawn');
   });
 
-  // Canary: protects the `timeout !== undefined` half of the SIGTERM guard —
-  // without a caller-supplied timeout, SIGTERM must fall through to the normal report-read path.
-  it('does not treat SIGTERM as a timeout error when no timeout was specified', async () => {
-    spawnSyncMock.mockReturnValueOnce({ status: null, signal: 'SIGTERM', stdout: '', stderr: '' });
-    const data = parseResult(await client.callTool({ name: 'run_tests', arguments: {} }));
-    expect(data.exitCode).toBe(-1);
-    expect(data.stats).toEqual(stats);
+  it('reports the default 300000 ms in the timeout message when no timeout was specified', async () => {
+    const timeoutError = Object.assign(new Error('spawnSync npx ETIMEDOUT'), { code: 'ETIMEDOUT' });
+    spawnSyncMock.mockReturnValueOnce({
+      status: null,
+      signal: 'SIGTERM',
+      error: timeoutError,
+      stdout: '',
+      stderr: '',
+    });
+    const result = await client.callTool({ name: 'run_tests', arguments: {} });
+    expect(result.isError).toBe(true);
+    const text = (result.content as TextContent[])[0].text;
+    expect(text).toContain('exceeded the 300000ms timeout');
   });
 });
 


### PR DESCRIPTION
## Summary

- `run_tests` now surfaces the intended friendly timeout message (`Playwright test run exceeded the ${ms}ms timeout and was killed.`) when `spawnSync` hits its timer. Previously the generic `Failed to spawn Playwright: spawnSync npx ETIMEDOUT` path always won, because Node 22 populates `error.code === 'ETIMEDOUT'` *and* `signal === 'SIGTERM'` and the `result.error` branch was checked first.
- The unreachable `if (timeout !== undefined && result.signal === 'SIGTERM')` block is gone; the new ETIMEDOUT branch runs regardless of whether the caller passed an explicit `timeout`, falling back to the default `300_000` ms in the message.
- `list_tests` had the same dead-code shape against its hardcoded 30s cap (`runPlaywright(buildListTestsCmd(tag), 30_000)`). Same fix applied, using the same `'code' in result.error` narrowing and a parallel WHY comment so the two sites read identically. User-facing message: `Listing Playwright tests exceeded the 30000ms timeout and was killed.`. Issue #64's acceptance criteria asked us to verify list_tests; on inspection it's the same bug with a narrower trigger surface, so it is fixed here.
- Tests updated:
  - The existing SIGTERM-only `run_tests` timeout test now also sets `error.code = 'ETIMEDOUT'`, matching what Node actually returns, and asserts the message does *not* contain `Failed to spawn`.
  - Added a `run_tests` case covering the no-explicit-timeout path (message reports `300000 ms`).
  - Added a `list_tests` ETIMEDOUT case asserting the friendly `exceeded the 30000ms timeout` message.
  - Removed the canary for the deleted `timeout !== undefined` guard — it no longer has anything to protect.

## Test plan

- [x] `npm run build`
- [x] `npm test` — 52 passed (was 51 after the initial commit; +1 `list_tests` ETIMEDOUT case)
- [x] `npm run format:check`

Closes #64
