### PR TITLE
#69 ci: migrate npm publish to Trusted Publishing (OIDC) and bump to 2.0.1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,9 +76,9 @@ jobs:
             --generate-notes \
             --verify-tag
 
-      # TODO: migrate to npm Trusted Publishing (OIDC) — drop NODE_AUTH_TOKEN
-      # once the trusted publisher is configured on npmjs.com against this repo
-      # and workflow. See https://docs.npmjs.com/trusted-publishers
+      # Auth via npm Trusted Publishing (OIDC). The `id-token: write` permission
+      # above lets npm exchange the GitHub OIDC token for a short-lived publish
+      # token — no NPM_TOKEN secret needed. Requires the trusted publisher to
+      # be configured on npmjs.com for this repo + workflow.
+      # https://docs.npmjs.com/trusted-publishers
       - run: npm publish --access public --provenance
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "playwright-report-mcp",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "playwright-report-mcp",
-      "version": "2.0.0",
+      "version": "2.0.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "playwright-report-mcp",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "mcpName": "io.github.hubertgajewski/playwright-report-mcp",
   "description": "MCP server for running Playwright tests and reading structured results — designed for AI agents doing test failure analysis",
   "type": "module",

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/hubertgajewski/playwright-report-mcp",
     "source": "github"
   },
-  "version": "2.0.0",
+  "version": "2.0.1",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "playwright-report-mcp",
-      "version": "2.0.0",
+      "version": "2.0.1",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
## Summary

- **OIDC migration**: drop `NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}` from the `npm publish` step in `release.yml`. The existing `id-token: write` permission is what npm uses to exchange the GitHub OIDC token for a short-lived publish credential — no long-lived `NPM_TOKEN` secret needed. Replaces the in-file TODO with a comment explaining the auth flow.
- **Version bump to 2.0.1** across the three sync'd fields (`package.json`, `server.json` top-level, `server.json` `packages[0]`) plus the regenerated `package-lock.json`. This release doubles as the live smoke test for PR #65 (the `release.yml`-folded chain) and this PR's OIDC switch.

Closes #69.

## Prerequisite — must be done before merging

Configure the trusted publisher on **npmjs.com** for `playwright-report-mcp`:

- Repository: `hubertgajewski/playwright-report-mcp`
- Workflow filename: `release.yml`
- (Environment can be left blank unless we add one.)

Without this, the first publish after merge will fail at `npm publish` with an authentication error. After the trusted publisher is configured, the `NPM_TOKEN` secret in repo settings can be deleted (it's no longer referenced).

## Test plan

- [x] `npm run build`
- [x] `npm test` — 52 passed
- [x] `npm run format:check`
- [ ] **Live smoke test**: after merge, tag `v2.0.1` on the merge commit and push. Watch:
  - `Release` workflow publishes the GitHub Release and runs `npm publish` successfully via OIDC (no `NODE_AUTH_TOKEN` env in logs).
  - `Publish to MCP registry` fires via `workflow_run` of `Release` (validating PR #65's `event == 'push'` guard).
  - `npm view playwright-report-mcp@2.0.1 version` returns `2.0.1`.
  - The MCP registry search at `https://registry.modelcontextprotocol.io/v0.1/servers?search=playwright-report-mcp` returns `2.0.1`.
