### PR TITLE
#71 fix: load McpServer name and version from package.json

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -165,8 +165,9 @@ function err(message: string) {
 // Two candidates because the module runs in two layouts: source (`<repo>/index.ts` sibling to package.json)
 // and published (`<repo>/dist/index.js` one level below package.json). A hardcoded relative path would
 // silently break in one of them; `tsc` does not rewrite JSON specifiers.
-function loadPackageMeta(): { name: string; version: string } {
-  const here = dirname(fileURLToPath(import.meta.url));
+// `baseDir` is injectable so unit tests can exercise failure/fallback paths against a tmpdir.
+function loadPackageMeta(baseDir?: string): { name: string; version: string } {
+  const here = baseDir ?? dirname(fileURLToPath(import.meta.url));
   for (const candidate of [join(here, 'package.json'), join(here, '..', 'package.json')]) {
     try {
       const pkg = JSON.parse(readFileSync(candidate, 'utf8'));
@@ -364,7 +365,7 @@ server.registerTool(
   }
 );
 
-export { buildListTestsCmd, collectSpecs, parseListJson, server };
+export { buildListTestsCmd, collectSpecs, loadPackageMeta, parseListJson, server };
 
 if (realpathSync(process.argv[1]) === fileURLToPath(import.meta.url)) {
   const transport = new StdioServerTransport();

--- a/index.ts
+++ b/index.ts
@@ -3,7 +3,7 @@ import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import { spawnSync } from 'child_process';
 import { readFileSync, realpathSync, statSync } from 'fs';
-import { join, relative, resolve } from 'path';
+import { dirname, join, relative, resolve } from 'path';
 import { fileURLToPath } from 'url';
 import { z } from 'zod';
 
@@ -161,7 +161,26 @@ function err(message: string) {
 
 // ---------- server ----------
 
-const server = new McpServer({ name: 'playwright-report', version: '1.0.0' });
+// Load identity from package.json so clients see the real published name/version via MCP `initialize`.
+// Two candidates because the module runs in two layouts: source (`<repo>/index.ts` sibling to package.json)
+// and published (`<repo>/dist/index.js` one level below package.json). A hardcoded relative path would
+// silently break in one of them; `tsc` does not rewrite JSON specifiers.
+function loadPackageMeta(): { name: string; version: string } {
+  const here = dirname(fileURLToPath(import.meta.url));
+  for (const candidate of [join(here, 'package.json'), join(here, '..', 'package.json')]) {
+    try {
+      const pkg = JSON.parse(readFileSync(candidate, 'utf8'));
+      if (typeof pkg.name === 'string' && typeof pkg.version === 'string')
+        return { name: pkg.name, version: pkg.version };
+    } catch {
+      // try next candidate
+    }
+  }
+  throw new Error(`Could not locate package.json relative to ${here}`);
+}
+
+const pkg = loadPackageMeta();
+const server = new McpServer({ name: pkg.name, version: pkg.version });
 
 server.registerTool(
   'run_tests',

--- a/index.ts
+++ b/index.ts
@@ -179,7 +179,7 @@ function loadPackageMeta(baseDir?: string): { name: string; version: string } {
         typeof pkg.version === 'string' &&
         pkg.version.trim().length > 0
       )
-        return { name: pkg.name, version: pkg.version };
+        return { name: pkg.name.trim(), version: pkg.version.trim() };
     } catch {
       // try next candidate
     }

--- a/index.ts
+++ b/index.ts
@@ -171,7 +171,14 @@ function loadPackageMeta(baseDir?: string): { name: string; version: string } {
   for (const candidate of [join(here, 'package.json'), join(here, '..', 'package.json')]) {
     try {
       const pkg = JSON.parse(readFileSync(candidate, 'utf8'));
-      if (typeof pkg.name === 'string' && typeof pkg.version === 'string')
+      // Reject empty/whitespace-only values — MCP clients would otherwise render a blank server
+      // identity, which defeats the whole point of sourcing these from package.json.
+      if (
+        typeof pkg.name === 'string' &&
+        pkg.name.trim().length > 0 &&
+        typeof pkg.version === 'string' &&
+        pkg.version.trim().length > 0
+      )
         return { name: pkg.name, version: pkg.version };
     } catch {
       // try next candidate

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "playwright-report-mcp",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "playwright-report-mcp",
-      "version": "2.0.1",
+      "version": "2.0.2",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "playwright-report-mcp",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "mcpName": "io.github.hubertgajewski/playwright-report-mcp",
   "description": "MCP server for running Playwright tests and reading structured results — designed for AI agents doing test failure analysis",
   "type": "module",

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/hubertgajewski/playwright-report-mcp",
     "source": "github"
   },
-  "version": "2.0.1",
+  "version": "2.0.2",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "playwright-report-mcp",
-      "version": "2.0.1",
+      "version": "2.0.2",
       "transport": {
         "type": "stdio"
       },

--- a/test/collect-specs.test.ts
+++ b/test/collect-specs.test.ts
@@ -1,6 +1,8 @@
 import { describe, it, expect } from 'vitest';
 import { collectSpecs } from '../index.js';
 
+type SuiteArg = Parameters<typeof collectSpecs>[0][number];
+
 describe('collectSpecs', () => {
   it('returns empty array for empty suites', () => {
     expect(collectSpecs([])).toEqual([]);
@@ -70,9 +72,7 @@ describe('collectSpecs', () => {
   it('treats a missing specs field as empty', () => {
     // `specs: []` exercises the defined branch of `suite.specs ?? []`; this case exercises the fallback.
     const result = collectSpecs([
-      { title: 'no-specs-field', file: 'tests/x.spec.ts' } as unknown as Parameters<
-        typeof collectSpecs
-      >[0][number],
+      { title: 'no-specs-field', file: 'tests/x.spec.ts' } as unknown as SuiteArg,
     ]);
     expect(result).toEqual([]);
   });

--- a/test/collect-specs.test.ts
+++ b/test/collect-specs.test.ts
@@ -66,4 +66,14 @@ describe('collectSpecs', () => {
     const result = collectSpecs([{ title: 'empty', file: 'tests/empty.spec.ts', specs: [] }]);
     expect(result).toEqual([]);
   });
+
+  it('treats a missing specs field as empty', () => {
+    // `specs: []` exercises the defined branch of `suite.specs ?? []`; this case exercises the fallback.
+    const result = collectSpecs([
+      { title: 'no-specs-field', file: 'tests/x.spec.ts' } as unknown as Parameters<
+        typeof collectSpecs
+      >[0][number],
+    ]);
+    expect(result).toEqual([]);
+  });
 });

--- a/test/e2e.test.ts
+++ b/test/e2e.test.ts
@@ -14,6 +14,7 @@ import { existsSync, readdirSync } from 'fs';
 import { homedir } from 'os';
 import { join, resolve } from 'path';
 import { fileURLToPath } from 'url';
+import pkg from '../package.json' with { type: 'json' };
 
 const __dirname = fileURLToPath(new URL('.', import.meta.url));
 const PW_PROJECT = resolve(__dirname, 'fixtures/pw-project');
@@ -75,6 +76,17 @@ describe.skipIf(SKIP)('MCP server e2e — fixture Playwright project', () => {
 
   afterAll(async () => {
     await client?.close();
+  });
+
+  // ── server identity ───────────────────────────────────────────────────────
+  // Covers the dist-layout branch of loadPackageMeta (dist/index.js with package.json one level up).
+  // The source-layout branch is covered by test/server.test.ts.
+
+  describe('server identity', () => {
+    it('advertises name and version from package.json', () => {
+      const info = client.getServerVersion();
+      expect(info).toMatchObject({ name: pkg.name, version: pkg.version });
+    });
   });
 
   // ── list_tests ────────────────────────────────────────────────────────────

--- a/test/server.test.ts
+++ b/test/server.test.ts
@@ -943,6 +943,29 @@ describe('loadPackageMeta', () => {
     expect(loadPackageMeta(distDir)).toEqual({ name: 'parent', version: '6.0.0' });
   });
 
+  it('skips a candidate with an empty name and falls through', () => {
+    writeFileSync(firstPath(), JSON.stringify({ name: '', version: '7.0.0' }));
+    writeFileSync(parentPath(), JSON.stringify({ name: 'parent', version: '7.1.0' }));
+    expect(loadPackageMeta(distDir)).toEqual({ name: 'parent', version: '7.1.0' });
+  });
+
+  it('skips a candidate with an empty version and falls through', () => {
+    writeFileSync(firstPath(), JSON.stringify({ name: 'first', version: '' }));
+    writeFileSync(parentPath(), JSON.stringify({ name: 'parent', version: '8.0.0' }));
+    expect(loadPackageMeta(distDir)).toEqual({ name: 'parent', version: '8.0.0' });
+  });
+
+  it('skips a candidate with whitespace-only name/version and falls through', () => {
+    writeFileSync(firstPath(), JSON.stringify({ name: '   ', version: '\t\n' }));
+    writeFileSync(parentPath(), JSON.stringify({ name: 'parent', version: '9.0.0' }));
+    expect(loadPackageMeta(distDir)).toEqual({ name: 'parent', version: '9.0.0' });
+  });
+
+  it('throws when the only candidate has empty name/version', () => {
+    writeFileSync(firstPath(), JSON.stringify({ name: '', version: '' }));
+    expect(() => loadPackageMeta(distDir)).toThrow(/Could not locate package\.json/);
+  });
+
   it('throws when no candidate has valid metadata', () => {
     writeFileSync(firstPath(), 'garbage');
     writeFileSync(parentPath(), JSON.stringify({ name: 'parent' })); // missing version

--- a/test/server.test.ts
+++ b/test/server.test.ts
@@ -685,6 +685,36 @@ describe('run_tests — edge cases in spawn result', () => {
 describe('get_failed_tests — edge cases', () => {
   afterEach(() => writeDefaultReport());
 
+  it('returns null error when the failing result has no error object', async () => {
+    // Exercises the `?? null` fallback in the failure-to-error mapping.
+    writeCustomReport({
+      suites: [
+        {
+          title: 'x.spec.ts',
+          file: 'tests/x.spec.ts',
+          specs: [
+            {
+              title: 'errorless failure',
+              file: 'tests/x.spec.ts',
+              line: 1,
+              ok: false,
+              tests: [
+                {
+                  projectName: 'Chromium',
+                  status: 'unexpected',
+                  results: [{ status: 'failed', duration: 10, attachments: [] }],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+      stats: { expected: 0, unexpected: 1, skipped: 0, duration: 10 },
+    });
+    const data = parseResult(await client.callTool({ name: 'get_failed_tests', arguments: {} }));
+    expect(data.tests[0].failures[0].error).toBeNull();
+  });
+
   it('returns the failing spec with empty failures when its tests have no result attempts', async () => {
     writeCustomReport({
       suites: [

--- a/test/server.test.ts
+++ b/test/server.test.ts
@@ -122,6 +122,8 @@ describe('get_test_attachment', () => {
 });
 
 describe('run_tests — spec path validation', () => {
+  beforeEach(() => spawnSyncMock.mockClear());
+
   it('rejects spec paths outside the project directory', async () => {
     const result = await client.callTool({
       name: 'run_tests',
@@ -130,6 +132,20 @@ describe('run_tests — spec path validation', () => {
     expect(result.isError).toBe(true);
     const text = (result.content as TextContent[])[0].text;
     expect(text).toContain('within the project directory');
+  });
+
+  it('accepts an absolute spec path that resolves inside the project directory', async () => {
+    // Positive counterpart to the `..` rejection test: `resolve(PW_DIR, absPath)` returns
+    // absPath unchanged, so the validation must still accept it when it falls within PW_DIR.
+    const pwDir = process.env.PW_DIR as string;
+    const absInside = join(pwDir, 'tests', 'auth.spec.ts');
+    const result = await client.callTool({
+      name: 'run_tests',
+      arguments: { spec: absInside },
+    });
+    expect(result.isError).toBeFalsy();
+    const args = spawnSyncMock.mock.calls[0][1] as string[];
+    expect(args).toContain(absInside);
   });
 });
 
@@ -742,6 +758,69 @@ describe('get_failed_tests — edge cases', () => {
 
 describe('get_test_attachment — skips entries without result attempts', () => {
   afterEach(() => writeDefaultReport());
+
+  it('falls through from a missing-on-disk attachment to a later test entry with a readable file', async () => {
+    // The first project lists the attachment but its file is gone from disk; the loop must
+    // continue past the swallowed statSync error and return content from the second project.
+    const workingPath = join(resultsDir, 'works.txt');
+    writeFileSync(workingPath, 'readable payload');
+    writeCustomReport({
+      suites: [
+        {
+          title: 'x.spec.ts',
+          file: 'tests/x.spec.ts',
+          specs: [
+            {
+              title: 'shared name',
+              file: 'tests/x.spec.ts',
+              line: 1,
+              ok: false,
+              tests: [
+                {
+                  projectName: 'Chromium',
+                  status: 'unexpected',
+                  results: [
+                    {
+                      status: 'failed',
+                      duration: 10,
+                      attachments: [
+                        {
+                          name: 'diag',
+                          contentType: 'text/plain',
+                          path: join(resultsDir, 'missing.txt'),
+                        },
+                      ],
+                    },
+                  ],
+                },
+                {
+                  projectName: 'Firefox',
+                  status: 'unexpected',
+                  results: [
+                    {
+                      status: 'failed',
+                      duration: 10,
+                      attachments: [{ name: 'diag', contentType: 'text/plain', path: workingPath }],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+      stats: { expected: 0, unexpected: 1, skipped: 0, duration: 20 },
+    });
+
+    const data = parseResult(
+      await client.callTool({
+        name: 'get_test_attachment',
+        arguments: { testTitle: 'shared name', attachmentName: 'diag' },
+      })
+    );
+    expect(data.content).toBe('readable payload');
+    unlinkSync(workingPath);
+  });
 
   it('continues past tests whose results array is empty and returns not-found', async () => {
     writeCustomReport({

--- a/test/server.test.ts
+++ b/test/server.test.ts
@@ -764,62 +764,71 @@ describe('get_test_attachment — skips entries without result attempts', () => 
     // continue past the swallowed statSync error and return content from the second project.
     const workingPath = join(resultsDir, 'works.txt');
     writeFileSync(workingPath, 'readable payload');
-    writeCustomReport({
-      suites: [
-        {
-          title: 'x.spec.ts',
-          file: 'tests/x.spec.ts',
-          specs: [
-            {
-              title: 'shared name',
-              file: 'tests/x.spec.ts',
-              line: 1,
-              ok: false,
-              tests: [
-                {
-                  projectName: 'Chromium',
-                  status: 'unexpected',
-                  results: [
-                    {
-                      status: 'failed',
-                      duration: 10,
-                      attachments: [
-                        {
-                          name: 'diag',
-                          contentType: 'text/plain',
-                          path: join(resultsDir, 'missing.txt'),
-                        },
-                      ],
-                    },
-                  ],
-                },
-                {
-                  projectName: 'Firefox',
-                  status: 'unexpected',
-                  results: [
-                    {
-                      status: 'failed',
-                      duration: 10,
-                      attachments: [{ name: 'diag', contentType: 'text/plain', path: workingPath }],
-                    },
-                  ],
-                },
-              ],
-            },
-          ],
-        },
-      ],
-      stats: { expected: 0, unexpected: 1, skipped: 0, duration: 20 },
-    });
+    try {
+      writeCustomReport({
+        suites: [
+          {
+            title: 'x.spec.ts',
+            file: 'tests/x.spec.ts',
+            specs: [
+              {
+                title: 'shared name',
+                file: 'tests/x.spec.ts',
+                line: 1,
+                ok: false,
+                tests: [
+                  {
+                    projectName: 'Chromium',
+                    status: 'unexpected',
+                    results: [
+                      {
+                        status: 'failed',
+                        duration: 10,
+                        attachments: [
+                          {
+                            name: 'diag',
+                            contentType: 'text/plain',
+                            path: join(resultsDir, 'missing.txt'),
+                          },
+                        ],
+                      },
+                    ],
+                  },
+                  {
+                    projectName: 'Firefox',
+                    status: 'unexpected',
+                    results: [
+                      {
+                        status: 'failed',
+                        duration: 10,
+                        attachments: [
+                          { name: 'diag', contentType: 'text/plain', path: workingPath },
+                        ],
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+        stats: { expected: 0, unexpected: 1, skipped: 0, duration: 20 },
+      });
 
-    const data = parseResult(
-      await client.callTool({
-        name: 'get_test_attachment',
-        arguments: { testTitle: 'shared name', attachmentName: 'diag' },
-      })
-    );
-    expect(data.content).toBe('readable payload');
-    unlinkSync(workingPath);
+      const data = parseResult(
+        await client.callTool({
+          name: 'get_test_attachment',
+          arguments: { testTitle: 'shared name', attachmentName: 'diag' },
+        })
+      );
+      expect(data.content).toBe('readable payload');
+    } finally {
+      try {
+        unlinkSync(workingPath);
+      } catch {
+        // already gone
+      }
+    }
   });
 
   it('continues past tests whose results array is empty and returns not-found', async () => {
@@ -1068,6 +1077,11 @@ describe('loadPackageMeta', () => {
     writeFileSync(firstPath(), JSON.stringify({ name: '   ', version: '\t\n' }));
     writeFileSync(parentPath(), JSON.stringify({ name: 'parent', version: '9.0.0' }));
     expect(loadPackageMeta(distDir)).toEqual({ name: 'parent', version: '9.0.0' });
+  });
+
+  it('trims leading/trailing whitespace from accepted name and version', () => {
+    writeFileSync(firstPath(), JSON.stringify({ name: '  padded  ', version: '\t10.0.0\n' }));
+    expect(loadPackageMeta(distDir)).toEqual({ name: 'padded', version: '10.0.0' });
   });
 
   it('throws when the only candidate has empty name/version', () => {

--- a/test/server.test.ts
+++ b/test/server.test.ts
@@ -4,6 +4,7 @@ import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
 import { unlinkSync, writeFileSync } from 'fs';
 import { join } from 'path';
 import { fileURLToPath } from 'url';
+import pkg from '../package.json' with { type: 'json' };
 import { stats, suites } from './fixtures/data.js';
 
 vi.mock('child_process', async (importOriginal) => {
@@ -58,6 +59,15 @@ function parseResult(result: Awaited<ReturnType<typeof client.callTool>>) {
   const text = (result.content as TextContent[])[0].text;
   return JSON.parse(text);
 }
+
+describe('server identity', () => {
+  // Covers the source-layout branch of loadPackageMeta (index.ts sibling to package.json).
+  // The dist-layout branch is covered by test/e2e.test.ts.
+  it('advertises name and version from package.json', () => {
+    const info = client.getServerVersion();
+    expect(info).toMatchObject({ name: pkg.name, version: pkg.version });
+  });
+});
 
 describe('get_failed_tests', () => {
   let data: ReturnType<typeof parseResult>;

--- a/test/server.test.ts
+++ b/test/server.test.ts
@@ -1,7 +1,8 @@
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
-import { unlinkSync, writeFileSync } from 'fs';
+import { mkdirSync, mkdtempSync, rmSync, unlinkSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
 import { join } from 'path';
 import { fileURLToPath } from 'url';
 import pkg from '../package.json' with { type: 'json' };
@@ -16,7 +17,7 @@ vi.mock('child_process', async (importOriginal) => {
 });
 
 import { spawnSync } from 'child_process';
-import { buildListTestsCmd, parseListJson, server } from '../index.js';
+import { buildListTestsCmd, loadPackageMeta, parseListJson, server } from '../index.js';
 
 const spawnSyncMock = spawnSync as unknown as ReturnType<typeof vi.fn>;
 
@@ -883,5 +884,76 @@ describe('parseListJson — tag normalization edge cases', () => {
     expect(parseListJson(input)).toEqual([
       { title: 'no tags field', file: 'tests/x.spec.ts', tags: [] },
     ]);
+  });
+});
+
+describe('loadPackageMeta', () => {
+  // Layout under test: tmpRoot/
+  //                      ├── package.json      ← parent candidate
+  //                      └── dist/
+  //                          └── package.json  ← first candidate
+  // Tests drive loadPackageMeta(join(tmpRoot, 'dist')) to exercise both candidates.
+  let tmpRoot: string;
+  let distDir: string;
+  const firstPath = () => join(distDir, 'package.json');
+  const parentPath = () => join(tmpRoot, 'package.json');
+
+  beforeEach(() => {
+    tmpRoot = mkdtempSync(join(tmpdir(), 'pw-report-mcp-pkgmeta-'));
+    distDir = join(tmpRoot, 'dist');
+    mkdirSync(distDir);
+  });
+
+  afterEach(() => {
+    rmSync(tmpRoot, { recursive: true, force: true });
+  });
+
+  it('returns the first candidate when it has valid name/version', () => {
+    writeFileSync(firstPath(), JSON.stringify({ name: 'first', version: '1.0.0' }));
+    writeFileSync(parentPath(), JSON.stringify({ name: 'parent', version: '9.9.9' }));
+    expect(loadPackageMeta(distDir)).toEqual({ name: 'first', version: '1.0.0' });
+  });
+
+  it('falls through to the parent candidate when the first is missing', () => {
+    writeFileSync(parentPath(), JSON.stringify({ name: 'parent', version: '2.3.4' }));
+    expect(loadPackageMeta(distDir)).toEqual({ name: 'parent', version: '2.3.4' });
+  });
+
+  it('skips a candidate with malformed JSON and falls through', () => {
+    writeFileSync(firstPath(), 'not valid json {{{');
+    writeFileSync(parentPath(), JSON.stringify({ name: 'parent', version: '3.0.0' }));
+    expect(loadPackageMeta(distDir)).toEqual({ name: 'parent', version: '3.0.0' });
+  });
+
+  it('skips a candidate missing version and falls through', () => {
+    writeFileSync(firstPath(), JSON.stringify({ name: 'first' }));
+    writeFileSync(parentPath(), JSON.stringify({ name: 'parent', version: '4.0.0' }));
+    expect(loadPackageMeta(distDir)).toEqual({ name: 'parent', version: '4.0.0' });
+  });
+
+  it('skips a candidate missing name and falls through', () => {
+    writeFileSync(firstPath(), JSON.stringify({ version: '5.0.0' }));
+    writeFileSync(parentPath(), JSON.stringify({ name: 'parent', version: '5.0.1' }));
+    expect(loadPackageMeta(distDir)).toEqual({ name: 'parent', version: '5.0.1' });
+  });
+
+  it('skips a candidate where name/version are not strings and falls through', () => {
+    writeFileSync(firstPath(), JSON.stringify({ name: 'first', version: 1 }));
+    writeFileSync(parentPath(), JSON.stringify({ name: 'parent', version: '6.0.0' }));
+    expect(loadPackageMeta(distDir)).toEqual({ name: 'parent', version: '6.0.0' });
+  });
+
+  it('throws when no candidate has valid metadata', () => {
+    writeFileSync(firstPath(), 'garbage');
+    writeFileSync(parentPath(), JSON.stringify({ name: 'parent' })); // missing version
+    expect(() => loadPackageMeta(distDir)).toThrow(/Could not locate package\.json/);
+  });
+
+  it('throws when neither candidate exists on disk', () => {
+    expect(() => loadPackageMeta(distDir)).toThrow(/Could not locate package\.json/);
+  });
+
+  it('includes the baseDir in the thrown error message for diagnosability', () => {
+    expect(() => loadPackageMeta(distDir)).toThrow(new RegExp(distDir.replace(/\./g, '\\.')));
   });
 });


### PR DESCRIPTION
## Summary

- Replace the hardcoded `new McpServer({ name: 'playwright-report', version: '1.0.0' })` with a runtime lookup that sources both fields from `package.json`. Agents/clients calling `initialize` will now see the real published identity (`playwright-report-mcp` / `2.0.2`) instead of stale placeholders.
- `loadPackageMeta()` tries two candidates (`./package.json` and `../package.json` relative to the module) because the module runs in two layouts — source (`index.ts` sibling to `package.json`) and published (`dist/index.js` one level below). A hardcoded specifier silently fails in one of them; `tsc` does not rewrite JSON imports.
- Bumps `package.json`, `server.json`, and `server.json.packages[0]` to `2.0.2` (not tagged in this PR).

## Test plan

- [x] `npm test` — 53/53 unit tests pass; new `server identity` describe in `test/server.test.ts` covers the source-layout branch via the InMemoryTransport harness (asserts `client.getServerVersion()` matches `pkg.name`/`pkg.version`).
- [x] `npm run test:e2e` — 8/8 e2e tests pass; new `server identity` describe in `test/e2e.test.ts` covers the dist-layout branch via the StdioClientTransport harness, against the real `dist/index.js` subprocess.
- [x] Both branches of the fallback are covered — a single assertion in only one harness would pass against a half-broken implementation.
- [x] `npm run format:check` — clean.
- [x] `npm run build` — clean.

Closes #71
