### PR TITLE
docs: move Contributing to CONTRIBUTING.md per GitHub convention

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,26 @@
+# Contributing
+
+Bug reports and pull requests are welcome. For significant changes, please open an issue first to discuss the approach.
+
+## Development setup
+
+```bash
+npm install
+npm run build
+npm test
+```
+
+Tests use [Vitest](https://vitest.dev/) and cover the `collectSpecs` helper (unit) and all four MCP tools via `InMemoryTransport` (integration). No build step or Playwright installation is required to run the test suite. See the [Development](README.md#development) section of the README for watch mode and more detail.
+
+## Code style
+
+[Prettier](https://prettier.io/) is the only formatter. Settings live in [`.prettierrc`](.prettierrc) (100-column width, single quotes, semicolons, 2-space indent, `trailingComma: es5`). Run `npm run format:check` locally before pushing — CI enforces it.
+
+There is no linter configured.
+
+## Commits and pull requests
+
+- **Commit messages:** short, single-line, imperative mood. Prefix with the issue number when applicable: `#123 fix: short summary`.
+- **PR titles** follow the same format as commit messages.
+- **PR body** should include `Closes #N` so the issue is automatically linked and closed on merge.
+- **Tests for new behavior are expected.** The harness is Vitest under [`test/`](test/); the test file for server tools is [`test/server.test.ts`](test/server.test.ts).

--- a/README.md
+++ b/README.md
@@ -353,7 +353,7 @@ git push origin v1.0.5
 
 ## Contributing
 
-Bug reports and pull requests are welcome. Please open an issue first for significant changes.
+See [CONTRIBUTING.md](CONTRIBUTING.md) for bug reports, pull requests, development setup, and commit conventions.
 
 ---
 


### PR DESCRIPTION
## Summary

- Extract `## Contributing` from `README.md` into a top-level `CONTRIBUTING.md` so GitHub surfaces it in the **New issue** and **Open pull request** flows ([community-file convention](https://docs.github.com/en/communities/setting-up-your-project-for-healthy-contributions/setting-up-your-project-for-healthy-contributions)).
- `CONTRIBUTING.md` covers: dev setup (`npm install` / `npm run build` / `npm test`), Prettier + `format:check` rule, commit-message + PR conventions (single-line, `#N Description` prefix, `Closes #N` in the body), and the "tests for new behavior via Vitest" expectation.
- `README.md` `## Contributing` is now a one-liner pointing at `CONTRIBUTING.md`.

No runtime or CI changes.

## Test plan

- [x] `npx prettier --check README.md CONTRIBUTING.md` passes.
- [x] After merge, confirm GitHub shows the `CONTRIBUTING.md` link on the New Issue / New PR pages.
