### PR TITLE
#78 feat: add per-call workingDirectory and PW_ALLOWED_DIRS allowlist

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,16 +156,19 @@ Tested with **Claude Code (CLI)**. Should work with any MCP-compatible client th
 
 ## Tools
 
+All four tools accept an optional `workingDirectory` parameter — see [Multi-worktree support](#multi-worktree-support).
+
 ### `run_tests`
 
 Runs the Playwright test suite and returns structured pass/fail results.
 
-| Input     | Type               | Description                                                                                                                                                                                                                                                     |
-| --------- | ------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `spec`    | string (optional)  | Spec file path relative to the project directory, e.g. `tests/login.spec.ts`. Must stay within the project directory.                                                                                                                                           |
-| `browser` | enum (optional)    | `Chromium`, `Firefox`, `Webkit`, `Mobile Chrome`, `Mobile Safari`                                                                                                                                                                                               |
-| `tag`     | string (optional)  | Tag filter, e.g. `@smoke`                                                                                                                                                                                                                                       |
-| `timeout` | integer (optional) | Timeout in milliseconds for the whole test run. Defaults to `300000` (5 min). Use a larger value for long suites or a smaller one to fail fast. When the run is killed by this timeout, the tool returns an explicit error rather than a generic non-zero exit. |
+| Input              | Type               | Description                                                                                                                                                                                                                                                     |
+| ------------------ | ------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `workingDirectory` | string (optional)  | Playwright project directory. Absolute or relative to the MCP server launch directory. Defaults to `"."`. Must be under `PW_ALLOWED_DIRS` — see [Multi-worktree support](#multi-worktree-support).                                                              |
+| `spec`             | string (optional)  | Spec file path relative to the project directory, e.g. `tests/login.spec.ts`. Must stay within the project directory.                                                                                                                                           |
+| `browser`          | enum (optional)    | `Chromium`, `Firefox`, `Webkit`, `Mobile Chrome`, `Mobile Safari`                                                                                                                                                                                               |
+| `tag`              | string (optional)  | Tag filter, e.g. `@smoke`                                                                                                                                                                                                                                       |
+| `timeout`          | integer (optional) | Timeout in milliseconds for the whole test run. Defaults to `300000` (5 min). Use a larger value for long suites or a smaller one to fail fast. When the run is killed by this timeout, the tool returns an explicit error rather than a generic non-zero exit. |
 
 Returns: exit code, run stats, and a summary of all tests with status, duration, and error per project.
 
@@ -173,26 +176,32 @@ Returns: exit code, run stats, and a summary of all tests with status, duration,
 
 Returns failed tests from the last run with error messages and attachment paths. Does not re-run tests — reads the existing `results.json`.
 
+| Input              | Type              | Description                                                               |
+| ------------------ | ----------------- | ------------------------------------------------------------------------- |
+| `workingDirectory` | string (optional) | See [Multi-worktree support](#multi-worktree-support). Defaults to `"."`. |
+
 Returns: failed test count, titles, file paths, per-project status, error messages, and attachment paths.
 
 ### `get_test_attachment`
 
 Reads the content of a named text attachment for a specific test from the last run.
 
-| Input            | Type   | Description                                                        |
-| ---------------- | ------ | ------------------------------------------------------------------ |
-| `testTitle`      | string | Exact test title as shown in the report                            |
-| `attachmentName` | string | Attachment name, e.g. `error-context`, `ai-diagnosis`, `page-html` |
+| Input              | Type              | Description                                                               |
+| ------------------ | ----------------- | ------------------------------------------------------------------------- |
+| `workingDirectory` | string (optional) | See [Multi-worktree support](#multi-worktree-support). Defaults to `"."`. |
+| `testTitle`        | string            | Exact test title as shown in the report                                   |
+| `attachmentName`   | string            | Attachment name, e.g. `error-context`, `ai-diagnosis`, `page-html`        |
 
-Returns: the attachment content as text. Binary attachments and files over 1 MB are rejected with an error.
+Returns: the attachment content as text. Binary attachments and files over 1 MB are rejected with an error. Attachment paths recorded in `results.json` that escape `workingDirectory` (via `..` or absolute paths pointing elsewhere) are refused.
 
 ### `list_tests`
 
 Lists all tests with their spec file and tags without running them.
 
-| Input | Type              | Description                  |
-| ----- | ----------------- | ---------------------------- |
-| `tag` | string (optional) | Filter by tag, e.g. `@smoke` |
+| Input              | Type              | Description                                                               |
+| ------------------ | ----------------- | ------------------------------------------------------------------------- |
+| `workingDirectory` | string (optional) | See [Multi-worktree support](#multi-worktree-support). Defaults to `"."`. |
+| `tag`              | string (optional) | Filter by tag, e.g. `@smoke`                                              |
 
 ---
 
@@ -244,35 +253,48 @@ Add to your `.mcp.json` at the root of your project:
 
 ### Environment variables
 
-| Variable          | Default                              | Description                                                                       |
-| ----------------- | ------------------------------------ | --------------------------------------------------------------------------------- |
-| `PW_DIR`          | `process.cwd()`                      | Root of the Playwright project — used as the working directory when running tests |
-| `PW_RESULTS_FILE` | `<PW_DIR>/test-results/results.json` | Absolute path to the JSON reporter output file                                    |
+| Variable          | Default                                        | Description                                                                                                                                                                      |
+| ----------------- | ---------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `PW_ALLOWED_DIRS` | `"."` (authorizes only the launch dir)         | `path.delimiter`-separated list of directories the `workingDirectory` parameter may point at. Entries may be absolute or relative (resolved once against launch cwd at startup). |
+| `PW_RESULTS_FILE` | `<workingDirectory>/test-results/results.json` | Absolute path to the JSON reporter output file. If set, overrides the per-call default for every call.                                                                           |
 
-Set `PW_RESULTS_FILE` if your `playwright.config.ts` writes the report to a non-default location.
+Set `PW_RESULTS_FILE` if your `playwright.config.ts` writes the report to a non-default location. Leave it unset in multi-worktree setups so each `workingDirectory` gets its own `test-results/results.json`.
 
-### Multiple Playwright projects
+### Multi-worktree support
 
-Use `PW_DIR` to point the server at any Playwright project directory. Register a separate entry per project:
+`run_tests`, `list_tests`, `get_failed_tests`, and `get_test_attachment` all accept an optional `workingDirectory` parameter — absolute, or relative to the MCP server's launch directory. This lets a single long-lived MCP session drive tests across multiple git worktrees without restarting.
+
+Because a Playwright config is a Node module that executes on `playwright test` startup, the server guards the parameter with an allowlist. Callers that point `workingDirectory` at a directory outside `PW_ALLOWED_DIRS` get a structured error and no child process is spawned.
+
+**Default (no worktrees).** Leave `PW_ALLOWED_DIRS` unset. The allowlist becomes `"."` — only the launch directory — and the default `workingDirectory` (also `"."`) resolves to the launch directory. Zero configuration.
+
+**Sibling worktrees.** Set `PW_ALLOWED_DIRS=".."` in your `.mcp.json` to authorize every sibling of the launch directory. Relative entries resolve against the launch cwd at startup, so the same `.mcp.json` works for every contributor without baking in absolute paths:
 
 ```json
 {
   "mcpServers": {
-    "playwright-report-mcp-e2e": {
+    "playwright-report-mcp": {
       "command": "npx",
       "args": ["-y", "playwright-report-mcp"],
-      "env": { "PW_DIR": "/absolute/path/to/your/e2e/project" },
-      "type": "stdio"
-    },
-    "playwright-report-mcp-integration": {
-      "command": "npx",
-      "args": ["-y", "playwright-report-mcp"],
-      "env": { "PW_DIR": "/absolute/path/to/your/integration/project" },
+      "env": { "PW_ALLOWED_DIRS": ".." },
       "type": "stdio"
     }
   }
 }
 ```
+
+Then point calls at any sibling worktree:
+
+```jsonc
+{
+  "name": "run_tests",
+  "arguments": { "workingDirectory": "../my-app-feat-auth" },
+}
+```
+
+**Multiple projects.** Either launch the MCP client from each project and use the default allowlist, or set `PW_ALLOWED_DIRS` to the shared parent and pass `workingDirectory` per call. The allowlist check runs at a path-segment boundary, so an entry authorizing `/src/my-app` will not authorize `/src/my-app-evil`.
+
+> **Breaking change (2.x → next):** the `PW_DIR` env var has been removed. Either launch the MCP client from inside the Playwright project directory (zero-config, default `workingDirectory: "."` works), or pass `workingDirectory` per call and set `PW_ALLOWED_DIRS` accordingly.
 
 ---
 

--- a/index.ts
+++ b/index.ts
@@ -3,14 +3,34 @@ import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import { spawnSync } from 'child_process';
 import { readFileSync, realpathSync, statSync } from 'fs';
-import { dirname, join, relative, resolve } from 'path';
+import { delimiter, dirname, isAbsolute, join, relative, resolve } from 'path';
 import { fileURLToPath } from 'url';
 import { z } from 'zod';
 
-const PW_DIR = resolve(process.env.PW_DIR ?? process.cwd());
-const RESULTS_FILE = resolve(
-  process.env.PW_RESULTS_FILE ?? join(PW_DIR, 'test-results', 'results.json')
-);
+// `launchCwd` is the working directory of the MCP server process at spawn
+// time. MCP stdio transports freeze the cwd for the process lifetime, so we
+// resolve it once here and use it as the anchor for per-call workingDirectory
+// resolution and for relative PW_ALLOWED_DIRS entries.
+const launchCwd = process.cwd();
+
+/**
+ * Parse PW_ALLOWED_DIRS into an array of absolute directory paths. Unset or
+ * empty collapses to a single "." entry (authorizing only launchCwd). Each
+ * entry is resolved against launchCwd exactly once at startup so relative
+ * entries in a committed .mcp.json encode layout, not per-user absolute paths.
+ */
+function parseAllowedDirs(raw: string | undefined, cwd: string): string[] {
+  const entries = raw === undefined || raw === '' ? ['.'] : raw.split(delimiter).filter(Boolean);
+  return entries.map((e) => resolve(cwd, e));
+}
+
+const ALLOWED_DIRS = parseAllowedDirs(process.env.PW_ALLOWED_DIRS, launchCwd);
+
+// Absolute override for results.json. If unset, the path is computed per-call
+// against the resolved workingDirectory.
+const RESULTS_FILE_OVERRIDE = process.env.PW_RESULTS_FILE
+  ? resolve(launchCwd, process.env.PW_RESULTS_FILE)
+  : null;
 
 // ---------- types (subset of Playwright JSON reporter output) ----------
 
@@ -61,9 +81,46 @@ interface PwReport {
 
 // ---------- helpers ----------
 
-function readLastReport(): PwReport | null {
+/**
+ * Segment-level containment check. Returns true when `child` equals `parent`
+ * or is a descendant of it. Rejects sibling-name bypasses (`/a/b` does not
+ * contain `/a/bextra`) by going through path.relative rather than a raw
+ * string-prefix match against `parent`.
+ */
+function isInside(parent: string, child: string): boolean {
+  if (child === parent) return true;
+  const rel = relative(parent, child);
+  return rel !== '' && !rel.startsWith('..') && !isAbsolute(rel);
+}
+
+/**
+ * Resolve a caller-supplied workingDirectory against launchCwd and apply the
+ * allowlist check. Returns the absolute directory on success, or an error
+ * string pinpointing the failed check.
+ */
+function resolveWorkingDir(
+  workingDirectory: string | undefined
+): { dir: string } | { error: string } {
+  const dir = resolve(launchCwd, workingDirectory ?? '.');
+  const ok = ALLOWED_DIRS.some((entry) => isInside(entry, dir));
+  if (!ok) {
+    return {
+      error:
+        `workingDirectory "${dir}" is not under any entry in PW_ALLOWED_DIRS ` +
+        `(allowed: ${ALLOWED_DIRS.join(', ')}). ` +
+        `Set PW_ALLOWED_DIRS to authorize additional directories.`,
+    };
+  }
+  return { dir };
+}
+
+function resultsFileFor(dir: string): string {
+  return RESULTS_FILE_OVERRIDE ?? join(dir, 'test-results', 'results.json');
+}
+
+function readLastReport(dir: string): PwReport | null {
   try {
-    return JSON.parse(readFileSync(RESULTS_FILE, 'utf8')) as PwReport;
+    return JSON.parse(readFileSync(resultsFileFor(dir), 'utf8')) as PwReport;
   } catch {
     return null;
   }
@@ -84,9 +141,9 @@ function collectSpecs(suites: PwSuite[], filePath = ''): Array<{ spec: PwSpec; f
   return out;
 }
 
-function runPlaywright(cmd: string[], timeoutMs: number) {
+function runPlaywright(cmd: string[], cwd: string, timeoutMs: number) {
   return spawnSync(cmd[0], cmd.slice(1), {
-    cwd: PW_DIR,
+    cwd,
     encoding: 'utf8',
     timeout: timeoutMs,
     maxBuffer: 10 * 1024 * 1024,
@@ -190,11 +247,19 @@ function loadPackageMeta(baseDir?: string): { name: string; version: string } {
 const pkg = loadPackageMeta();
 const server = new McpServer({ name: pkg.name, version: pkg.version });
 
+const workingDirectoryField = z
+  .string()
+  .optional()
+  .describe(
+    'Playwright project directory. Absolute or relative to the MCP server launch directory. Defaults to ".". Must be under PW_ALLOWED_DIRS.'
+  );
+
 server.registerTool(
   'run_tests',
   {
     description: 'Run Playwright tests and return structured results.',
     inputSchema: {
+      workingDirectory: workingDirectoryField,
       spec: z.string().optional().describe('Spec file path, e.g. tests/navigation.spec.ts'),
       browser: z
         .enum(['Chromium', 'Firefox', 'Webkit', 'Mobile Chrome', 'Mobile Safari'])
@@ -208,19 +273,21 @@ server.registerTool(
         .describe('Timeout in milliseconds for the whole test run. Defaults to 300000.'),
     },
   },
-  async ({ spec, browser, tag, timeout }) => {
+  async ({ workingDirectory, spec, browser, tag, timeout }) => {
+    const wd = resolveWorkingDir(workingDirectory);
+    if ('error' in wd) return err(wd.error);
+
     const cmd = ['npx', 'playwright', 'test'];
     if (spec) {
-      const resolved = resolve(PW_DIR, spec);
-      if (relative(PW_DIR, resolved).startsWith('..'))
-        return err('spec path must be within the project directory');
+      const resolved = resolve(wd.dir, spec);
+      if (!isInside(wd.dir, resolved)) return err('spec path must be within the project directory');
       cmd.push(resolved);
     }
     if (browser) cmd.push('--project', browser);
     if (tag) cmd.push('--grep', tag);
 
     const effectiveTimeout = timeout ?? 300_000;
-    const result = runPlaywright(cmd, effectiveTimeout);
+    const result = runPlaywright(cmd, wd.dir, effectiveTimeout);
 
     if (result.error) {
       // Node's spawnSync({ timeout }) populates BOTH error.code='ETIMEDOUT' and signal='SIGTERM'
@@ -232,7 +299,7 @@ server.registerTool(
       return err(`Failed to spawn Playwright: ${result.error.message}`);
     }
 
-    const report = readLastReport();
+    const report = readLastReport(wd.dir);
     if (!report)
       return err(
         `Test run completed but results.json was not found.\nstderr: ${result.stderr ?? ''}`
@@ -263,10 +330,15 @@ server.registerTool(
   'get_failed_tests',
   {
     description: 'Return failed tests from the last run with error messages and attachment paths.',
-    inputSchema: {},
+    inputSchema: {
+      workingDirectory: workingDirectoryField,
+    },
   },
-  async () => {
-    const report = readLastReport();
+  async ({ workingDirectory }) => {
+    const wd = resolveWorkingDir(workingDirectory);
+    if ('error' in wd) return err(wd.error);
+
+    const report = readLastReport(wd.dir);
     if (!report) return err('No results.json found — run tests first.');
 
     const failed = collectSpecs(report.suites)
@@ -299,12 +371,16 @@ server.registerTool(
   {
     description: 'Read the content of a named attachment for a specific test from the last run.',
     inputSchema: {
+      workingDirectory: workingDirectoryField,
       testTitle: z.string().describe('Exact test title as shown in the report'),
       attachmentName: z.string().describe('Attachment name, e.g. "AI diagnosis", "DOM"'),
     },
   },
-  async ({ testTitle, attachmentName }) => {
-    const report = readLastReport();
+  async ({ workingDirectory, testTitle, attachmentName }) => {
+    const wd = resolveWorkingDir(workingDirectory);
+    if ('error' in wd) return err(wd.error);
+
+    const report = readLastReport(wd.dir);
     if (!report) return err('No results.json found — run tests first.');
 
     const match = collectSpecs(report.suites).find(({ spec }) => spec.title === testTitle);
@@ -315,18 +391,25 @@ server.registerTool(
       if (!result) continue;
       const attachment = result.attachments.find((a) => a.name === attachmentName);
       if (attachment?.path) {
+        // Defense-in-depth: refuse to read any attachment whose path escapes
+        // the resolved workingDirectory, even if results.json recorded one.
+        const attachmentPath = resolve(wd.dir, attachment.path);
+        if (!isInside(wd.dir, attachmentPath))
+          return err(
+            `Attachment "${attachmentName}" path "${attachment.path}" escapes workingDirectory "${wd.dir}".`
+          );
         if (!attachment.contentType.startsWith('text/'))
           return err(
             `Attachment "${attachmentName}" is binary (${attachment.contentType}) and cannot be returned as text.`
           );
         try {
           const MAX_BYTES = 1_000_000;
-          const { size } = statSync(attachment.path);
+          const { size } = statSync(attachmentPath);
           if (size > MAX_BYTES)
             return err(
               `Attachment "${attachmentName}" is too large to return inline (${size} bytes).`
             );
-          return ok({ testTitle, attachmentName, content: readFileSync(attachment.path, 'utf8') });
+          return ok({ testTitle, attachmentName, content: readFileSync(attachmentPath, 'utf8') });
         } catch {
           // attachment path recorded in results.json but file no longer on disk
         }
@@ -341,12 +424,16 @@ server.registerTool(
   {
     description: 'List all tests with their spec file and tags without running them.',
     inputSchema: {
+      workingDirectory: workingDirectoryField,
       tag: z.string().optional().describe('Filter by tag, e.g. @smoke'),
     },
   },
-  async ({ tag }) => {
+  async ({ workingDirectory, tag }) => {
+    const wd = resolveWorkingDir(workingDirectory);
+    if ('error' in wd) return err(wd.error);
+
     const listTimeout = 30_000;
-    const result = runPlaywright(buildListTestsCmd(tag), listTimeout);
+    const result = runPlaywright(buildListTestsCmd(tag), wd.dir, listTimeout);
 
     if (result.error) {
       // Node's spawnSync({ timeout }) populates BOTH error.code='ETIMEDOUT' and signal='SIGTERM'
@@ -372,9 +459,26 @@ server.registerTool(
   }
 );
 
-export { buildListTestsCmd, collectSpecs, loadPackageMeta, parseListJson, server };
+export {
+  ALLOWED_DIRS,
+  buildListTestsCmd,
+  collectSpecs,
+  isInside,
+  loadPackageMeta,
+  parseAllowedDirs,
+  parseListJson,
+  server,
+};
 
 if (realpathSync(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  process.stderr.write(
+    `[playwright-report-mcp] launchCwd=${launchCwd}\n` +
+      `[playwright-report-mcp] PW_ALLOWED_DIRS=${ALLOWED_DIRS.join(', ')}` +
+      (process.env.PW_ALLOWED_DIRS === undefined || process.env.PW_ALLOWED_DIRS === ''
+        ? ' (default — authorizing only launchCwd)'
+        : '') +
+      '\n'
+  );
   const transport = new StdioServerTransport();
   await server.connect(transport);
 }

--- a/index.ts
+++ b/index.ts
@@ -2,7 +2,7 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import { spawnSync } from 'child_process';
-import { readFileSync, realpathSync, statSync } from 'fs';
+import { existsSync, readFileSync, realpathSync, statSync } from 'fs';
 import { delimiter, dirname, isAbsolute, join, relative, resolve } from 'path';
 import { fileURLToPath } from 'url';
 import { z } from 'zod';
@@ -24,7 +24,27 @@ function parseAllowedDirs(raw: string | undefined, cwd: string): string[] {
   return entries.map((e) => resolve(cwd, e));
 }
 
+/**
+ * Canonicalize a path via realpathSync, falling back to the lexical input when
+ * the path does not yet exist. Used to close symlink bypasses of the
+ * allowlist and attachment-path checks: lexical containment alone is
+ * insufficient because `spawnSync`'s `cwd` and `readFileSync` both follow
+ * symlinks, so a symlink inside an authorized directory can otherwise escape
+ * the allowlist.
+ */
+function canonicalize(p: string): string {
+  try {
+    return realpathSync(p);
+  } catch {
+    return p;
+  }
+}
+
 const ALLOWED_DIRS = parseAllowedDirs(process.env.PW_ALLOWED_DIRS, launchCwd);
+// Canonicalized allowlist entries, computed once at startup. A non-existent
+// entry falls back to the lexical path — that entry simply never matches a
+// real resolved path until the directory exists.
+const ALLOWED_DIRS_REAL = ALLOWED_DIRS.map(canonicalize);
 
 // Absolute override for results.json. If unset, the path is computed per-call
 // against the resolved workingDirectory.
@@ -102,8 +122,8 @@ function resolveWorkingDir(
   workingDirectory: string | undefined
 ): { dir: string } | { error: string } {
   const dir = resolve(launchCwd, workingDirectory ?? '.');
-  const ok = ALLOWED_DIRS.some((entry) => isInside(entry, dir));
-  if (!ok) {
+  const lexicallyOk = ALLOWED_DIRS.some((entry) => isInside(entry, dir));
+  if (!lexicallyOk) {
     return {
       error:
         `workingDirectory "${dir}" is not under any entry in PW_ALLOWED_DIRS ` +
@@ -111,7 +131,45 @@ function resolveWorkingDir(
         `Set PW_ALLOWED_DIRS to authorize additional directories.`,
     };
   }
-  return { dir };
+  // Explicit existence + directory check so the error pinpoints the failed check.
+  // Otherwise Playwright spawns with a missing cwd and ENOENT bubbles up as a
+  // generic "Failed to spawn" — a silent fall-through the issue specifically calls out.
+  if (!existsSync(dir)) return { error: `workingDirectory "${dir}" does not exist.` };
+  try {
+    if (!statSync(dir).isDirectory())
+      return { error: `workingDirectory "${dir}" exists but is not a directory.` };
+  } catch (e) {
+    return { error: `workingDirectory "${dir}" could not be stat'd: ${(e as Error).message}` };
+  }
+  // Symlink-safe containment: canonicalize the resolved directory and re-check
+  // against the canonicalized allowlist. This prevents a symlink inside an
+  // authorized directory from escaping the allowlist — `spawnSync`'s cwd
+  // follows symlinks at the OS level, so the lexical check alone is bypassable
+  // by anyone able to create a symlink under an authorized path.
+  const realDir = realpathSync(dir);
+  const reallyOk = ALLOWED_DIRS_REAL.some((entry) => isInside(entry, realDir));
+  if (!reallyOk) {
+    return {
+      error:
+        `workingDirectory "${dir}" resolves via symlink to "${realDir}", which is not under any ` +
+        `entry in PW_ALLOWED_DIRS (allowed: ${ALLOWED_DIRS_REAL.join(', ')}).`,
+    };
+  }
+  return { dir: realDir };
+}
+
+/**
+ * Format the one-line startup banner written to stderr when the server runs as
+ * a CLI. Extracted from the inline `process.stderr.write(...)` so operators'
+ * assumptions about what appears in their logs are covered by unit tests.
+ */
+function formatStartupBanner(cwd: string, allowed: string[], rawEnv: string | undefined): string {
+  const isDefault = rawEnv === undefined || rawEnv === '';
+  const suffix = isDefault ? ' (default — authorizing only launchCwd)' : '';
+  return (
+    `[playwright-report-mcp] launchCwd=${cwd}\n` +
+    `[playwright-report-mcp] PW_ALLOWED_DIRS=${allowed.join(', ')}${suffix}\n`
+  );
 }
 
 function resultsFileFor(dir: string): string {
@@ -393,6 +451,10 @@ server.registerTool(
       if (attachment?.path) {
         // Defense-in-depth: refuse to read any attachment whose path escapes
         // the resolved workingDirectory, even if results.json recorded one.
+        // Two checks — lexical first (fast, catches `..` traversal and absolute
+        // paths outside wd.dir), then symlink-safe via realpathSync so a
+        // symlink inside wd.dir pointing at /etc/passwd or ~/.ssh/id_rsa
+        // cannot smuggle data out through readFileSync (which follows symlinks).
         const attachmentPath = resolve(wd.dir, attachment.path);
         if (!isInside(wd.dir, attachmentPath))
           return err(
@@ -403,15 +465,25 @@ server.registerTool(
             `Attachment "${attachmentName}" is binary (${attachment.contentType}) and cannot be returned as text.`
           );
         try {
+          const realAttachmentPath = realpathSync(attachmentPath);
+          if (!isInside(wd.dir, realAttachmentPath))
+            return err(
+              `Attachment "${attachmentName}" path "${attachment.path}" resolves via symlink to "${realAttachmentPath}", which escapes workingDirectory "${wd.dir}".`
+            );
           const MAX_BYTES = 1_000_000;
-          const { size } = statSync(attachmentPath);
+          const { size } = statSync(realAttachmentPath);
           if (size > MAX_BYTES)
             return err(
               `Attachment "${attachmentName}" is too large to return inline (${size} bytes).`
             );
-          return ok({ testTitle, attachmentName, content: readFileSync(attachmentPath, 'utf8') });
+          return ok({
+            testTitle,
+            attachmentName,
+            content: readFileSync(realAttachmentPath, 'utf8'),
+          });
         } catch {
-          // attachment path recorded in results.json but file no longer on disk
+          // realpathSync / statSync / readFileSync throw if the file no longer
+          // exists on disk — fall through to the "not found" error below.
         }
       }
     }
@@ -461,8 +533,11 @@ server.registerTool(
 
 export {
   ALLOWED_DIRS,
+  ALLOWED_DIRS_REAL,
   buildListTestsCmd,
+  canonicalize,
   collectSpecs,
+  formatStartupBanner,
   isInside,
   loadPackageMeta,
   parseAllowedDirs,
@@ -471,14 +546,7 @@ export {
 };
 
 if (realpathSync(process.argv[1]) === fileURLToPath(import.meta.url)) {
-  process.stderr.write(
-    `[playwright-report-mcp] launchCwd=${launchCwd}\n` +
-      `[playwright-report-mcp] PW_ALLOWED_DIRS=${ALLOWED_DIRS.join(', ')}` +
-      (process.env.PW_ALLOWED_DIRS === undefined || process.env.PW_ALLOWED_DIRS === ''
-        ? ' (default — authorizing only launchCwd)'
-        : '') +
-      '\n'
-  );
+  process.stderr.write(formatStartupBanner(launchCwd, ALLOWED_DIRS, process.env.PW_ALLOWED_DIRS));
   const transport = new StdioServerTransport();
   await server.connect(transport);
 }

--- a/index.ts
+++ b/index.ts
@@ -2,7 +2,7 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import { spawnSync } from 'child_process';
-import { existsSync, readFileSync, realpathSync, statSync } from 'fs';
+import { readFileSync, realpathSync, statSync } from 'fs';
 import { delimiter, dirname, isAbsolute, join, relative, resolve } from 'path';
 import { fileURLToPath } from 'url';
 import { z } from 'zod';
@@ -131,16 +131,13 @@ function resolveWorkingDir(
         `Set PW_ALLOWED_DIRS to authorize additional directories.`,
     };
   }
-  // Explicit existence + directory check so the error pinpoints the failed check.
-  // Otherwise Playwright spawns with a missing cwd and ENOENT bubbles up as a
-  // generic "Failed to spawn" — a silent fall-through the issue specifically calls out.
-  if (!existsSync(dir)) return { error: `workingDirectory "${dir}" does not exist.` };
-  try {
-    if (!statSync(dir).isDirectory())
-      return { error: `workingDirectory "${dir}" exists but is not a directory.` };
-  } catch (e) {
-    return { error: `workingDirectory "${dir}" could not be stat'd: ${(e as Error).message}` };
-  }
+  // Pinpoint the failed check in the error message — otherwise Playwright
+  // spawns with a missing cwd and ENOENT surfaces as a generic "Failed to
+  // spawn", the silent fall-through the issue explicitly forbids.
+  const st = statSync(dir, { throwIfNoEntry: false });
+  if (!st) return { error: `workingDirectory "${dir}" does not exist.` };
+  if (!st.isDirectory())
+    return { error: `workingDirectory "${dir}" exists but is not a directory.` };
   // Symlink-safe containment: canonicalize the resolved directory and re-check
   // against the canonicalized allowlist. This prevents a symlink inside an
   // authorized directory from escaping the allowlist — `spawnSync`'s cwd
@@ -533,9 +530,7 @@ server.registerTool(
 
 export {
   ALLOWED_DIRS,
-  ALLOWED_DIRS_REAL,
   buildListTestsCmd,
-  canonicalize,
   collectSpecs,
   formatStartupBanner,
   isInside,

--- a/server.json
+++ b/server.json
@@ -17,15 +17,15 @@
       },
       "environmentVariables": [
         {
-          "name": "PW_DIR",
-          "description": "Root of the Playwright project — used as the working directory when running tests. Defaults to process.cwd().",
+          "name": "PW_ALLOWED_DIRS",
+          "description": "path.delimiter-separated list of directories the per-call workingDirectory parameter may point at. Entries may be absolute or relative (resolved once against the server's launch cwd at startup). Defaults to '.' (authorizes only the launch directory).",
           "isRequired": false,
           "format": "string",
           "isSecret": false
         },
         {
           "name": "PW_RESULTS_FILE",
-          "description": "Absolute path to the JSON reporter output file. Defaults to <PW_DIR>/test-results/results.json.",
+          "description": "Absolute path override for the JSON reporter output file. Defaults to <workingDirectory>/test-results/results.json, computed per call.",
           "isRequired": false,
           "format": "string",
           "isSecret": false

--- a/test/e2e.test.ts
+++ b/test/e2e.test.ts
@@ -63,11 +63,11 @@ describe.skipIf(SKIP)('MCP server e2e — fixture Playwright project', () => {
     for (const [k, v] of Object.entries(process.env)) {
       if (v !== undefined) env[k] = v;
     }
-    env.PW_DIR = PW_PROJECT;
-
+    // Launch the server with cwd = fixture project so default workingDirectory="." resolves there.
     const transport = new StdioClientTransport({
       command: 'node',
       args: [DIST_INDEX],
+      cwd: PW_PROJECT,
       env,
     });
     client = new Client({ name: 'e2e-client', version: '1.0.0' });

--- a/test/server.test.ts
+++ b/test/server.test.ts
@@ -17,7 +17,15 @@ vi.mock('child_process', async (importOriginal) => {
 });
 
 import { spawnSync } from 'child_process';
-import { buildListTestsCmd, loadPackageMeta, parseListJson, server } from '../index.js';
+import {
+  ALLOWED_DIRS,
+  buildListTestsCmd,
+  isInside,
+  loadPackageMeta,
+  parseAllowedDirs,
+  parseListJson,
+  server,
+} from '../index.js';
 
 const spawnSyncMock = spawnSync as unknown as ReturnType<typeof vi.fn>;
 
@@ -134,11 +142,10 @@ describe('run_tests — spec path validation', () => {
     expect(text).toContain('within the project directory');
   });
 
-  it('accepts an absolute spec path that resolves inside the project directory', async () => {
-    // Positive counterpart to the `..` rejection test: `resolve(PW_DIR, absPath)` returns
-    // absPath unchanged, so the validation must still accept it when it falls within PW_DIR.
-    const pwDir = process.env.PW_DIR as string;
-    const absInside = join(pwDir, 'tests', 'auth.spec.ts');
+  it('accepts an absolute spec path that resolves inside the working directory', async () => {
+    // Positive counterpart to the `..` rejection test: `resolve(wd, absPath)` returns
+    // absPath unchanged, so the validation must still accept it when it falls within wd.
+    const absInside = join(ALLOWED_DIRS[0], 'tests', 'auth.spec.ts');
     const result = await client.callTool({
       name: 'run_tests',
       arguments: { spec: absInside },
@@ -1101,5 +1108,243 @@ describe('loadPackageMeta', () => {
 
   it('includes the baseDir in the thrown error message for diagnosability', () => {
     expect(() => loadPackageMeta(distDir)).toThrow(new RegExp(distDir.replace(/\./g, '\\.')));
+  });
+});
+
+describe('isInside — segment-level containment', () => {
+  it('treats parent equal to child as contained', () => {
+    expect(isInside('/a/b', '/a/b')).toBe(true);
+  });
+
+  it('treats a strict descendant as contained', () => {
+    expect(isInside('/a/b', '/a/b/c')).toBe(true);
+    expect(isInside('/a/b', '/a/b/c/d')).toBe(true);
+  });
+
+  it('rejects a path above the parent', () => {
+    expect(isInside('/a/b', '/a')).toBe(false);
+  });
+
+  // Acceptance criterion: sibling-name bypass must be rejected. A raw
+  // String.prototype.startsWith('/a/b') would accept '/a/b-extra'.
+  it('rejects a sibling whose name shares a prefix with the parent', () => {
+    expect(isInside('/a/b', '/a/b-extra')).toBe(false);
+    expect(isInside('/Users/me/src/github/my-app', '/Users/me/src/github/my-app-evil')).toBe(false);
+  });
+
+  it('rejects a fully disjoint path', () => {
+    expect(isInside('/a/b', '/c/d')).toBe(false);
+  });
+});
+
+describe('parseAllowedDirs — startup resolution', () => {
+  it('defaults to a single "." entry when env is unset', () => {
+    expect(parseAllowedDirs(undefined, '/home/alice/proj')).toEqual(['/home/alice/proj']);
+  });
+
+  it('defaults to a single "." entry when env is the empty string', () => {
+    expect(parseAllowedDirs('', '/home/alice/proj')).toEqual(['/home/alice/proj']);
+  });
+
+  // Acceptance criterion: relative entries resolve against launchCwd so a
+  // committed .mcp.json works across contributors without baking absolute paths.
+  it('resolves relative entries against launchCwd — contributor A', () => {
+    expect(parseAllowedDirs('..', '/Users/alice/code/my-app')).toEqual(['/Users/alice/code']);
+  });
+
+  it('resolves relative entries against launchCwd — contributor B', () => {
+    expect(parseAllowedDirs('..', '/home/bob/src/my-app')).toEqual(['/home/bob/src']);
+  });
+
+  it('preserves absolute entries verbatim', () => {
+    expect(parseAllowedDirs('/etc', '/home/alice/proj')).toEqual(['/etc']);
+  });
+
+  it('splits multiple entries on path.delimiter', () => {
+    const sep = process.platform === 'win32' ? ';' : ':';
+    expect(parseAllowedDirs(`.${sep}..`, '/home/alice/proj')).toEqual([
+      '/home/alice/proj',
+      '/home/alice',
+    ]);
+  });
+});
+
+describe('workingDirectory — allowlist gate', () => {
+  beforeEach(() => spawnSyncMock.mockClear());
+
+  it('rejects workingDirectory outside the allowlist without spawning', async () => {
+    const result = await client.callTool({
+      name: 'run_tests',
+      arguments: { workingDirectory: '/etc' },
+    });
+    expect(result.isError).toBe(true);
+    const text = (result.content as TextContent[])[0].text;
+    expect(text).toContain('PW_ALLOWED_DIRS');
+    expect(spawnSyncMock).not.toHaveBeenCalled();
+  });
+
+  // Acceptance criterion: sibling-name bypass at the tool boundary.
+  // The allowlist is the repo root; '<repo-root>-evil' shares a prefix but is
+  // a sibling, so it must be rejected exactly like a disjoint path.
+  it('rejects sibling-name bypass at the tool boundary', async () => {
+    const sibling = ALLOWED_DIRS[0] + '-evil';
+    const result = await client.callTool({
+      name: 'run_tests',
+      arguments: { workingDirectory: sibling },
+    });
+    expect(result.isError).toBe(true);
+    const text = (result.content as TextContent[])[0].text;
+    expect(text).toContain('PW_ALLOWED_DIRS');
+    expect(spawnSyncMock).not.toHaveBeenCalled();
+  });
+
+  it('passes a workingDirectory under the allowlist as the spawn cwd', async () => {
+    await client.callTool({
+      name: 'run_tests',
+      arguments: { workingDirectory: 'test/fixtures' },
+    });
+    expect(spawnSyncMock).toHaveBeenCalledTimes(1);
+    const options = spawnSyncMock.mock.calls[0][2] as { cwd: string };
+    expect(options.cwd.endsWith('test/fixtures')).toBe(true);
+  });
+
+  it('omitting workingDirectory defaults to launchCwd — spawn cwd matches ALLOWED_DIRS[0]', async () => {
+    await client.callTool({ name: 'run_tests', arguments: {} });
+    expect(spawnSyncMock).toHaveBeenCalledTimes(1);
+    const options = spawnSyncMock.mock.calls[0][2] as { cwd: string };
+    expect(options.cwd).toBe(ALLOWED_DIRS[0]);
+  });
+
+  it('gates list_tests on the allowlist', async () => {
+    const result = await client.callTool({
+      name: 'list_tests',
+      arguments: { workingDirectory: '/etc' },
+    });
+    expect(result.isError).toBe(true);
+    expect((result.content as TextContent[])[0].text).toContain('PW_ALLOWED_DIRS');
+    expect(spawnSyncMock).not.toHaveBeenCalled();
+  });
+
+  it('gates get_failed_tests on the allowlist', async () => {
+    const result = await client.callTool({
+      name: 'get_failed_tests',
+      arguments: { workingDirectory: '/etc' },
+    });
+    expect(result.isError).toBe(true);
+    expect((result.content as TextContent[])[0].text).toContain('PW_ALLOWED_DIRS');
+  });
+
+  it('gates get_test_attachment on the allowlist', async () => {
+    const result = await client.callTool({
+      name: 'get_test_attachment',
+      arguments: {
+        workingDirectory: '/etc',
+        testTitle: 'login fails with wrong password',
+        attachmentName: 'diagnosis',
+      },
+    });
+    expect(result.isError).toBe(true);
+    expect((result.content as TextContent[])[0].text).toContain('PW_ALLOWED_DIRS');
+  });
+});
+
+describe('get_test_attachment — path-traversal defense', () => {
+  afterEach(() => writeDefaultReport());
+
+  // Acceptance criterion: attachment paths that escape workingDirectory must
+  // be rejected even if results.json records them. Craft a results.json whose
+  // attachment.path contains `..` components that escape the working dir.
+  it('rejects an attachment whose recorded path escapes workingDirectory via ..', async () => {
+    const escapingPath = join(resultsDir, '..', '..', '..', 'etc', 'passwd');
+    writeCustomReport({
+      suites: [
+        {
+          title: 'x.spec.ts',
+          file: 'tests/x.spec.ts',
+          specs: [
+            {
+              title: 'traversal test',
+              file: 'tests/x.spec.ts',
+              line: 1,
+              ok: false,
+              tests: [
+                {
+                  projectName: 'Chromium',
+                  status: 'unexpected',
+                  results: [
+                    {
+                      status: 'failed',
+                      duration: 10,
+                      attachments: [
+                        { name: 'diag', contentType: 'text/plain', path: escapingPath },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+      stats: { expected: 0, unexpected: 1, skipped: 0, duration: 10 },
+    });
+
+    const result = await client.callTool({
+      name: 'get_test_attachment',
+      arguments: {
+        workingDirectory: 'test/fixtures',
+        testTitle: 'traversal test',
+        attachmentName: 'diag',
+      },
+    });
+    expect(result.isError).toBe(true);
+    const text = (result.content as TextContent[])[0].text;
+    expect(text).toContain('escapes workingDirectory');
+  });
+
+  it('rejects an absolute attachment path outside workingDirectory', async () => {
+    writeCustomReport({
+      suites: [
+        {
+          title: 'x.spec.ts',
+          file: 'tests/x.spec.ts',
+          specs: [
+            {
+              title: 'absolute test',
+              file: 'tests/x.spec.ts',
+              line: 1,
+              ok: false,
+              tests: [
+                {
+                  projectName: 'Chromium',
+                  status: 'unexpected',
+                  results: [
+                    {
+                      status: 'failed',
+                      duration: 10,
+                      attachments: [
+                        { name: 'diag', contentType: 'text/plain', path: '/etc/passwd' },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+      stats: { expected: 0, unexpected: 1, skipped: 0, duration: 10 },
+    });
+
+    const result = await client.callTool({
+      name: 'get_test_attachment',
+      arguments: {
+        workingDirectory: 'test/fixtures',
+        testTitle: 'absolute test',
+        attachmentName: 'diag',
+      },
+    });
+    expect(result.isError).toBe(true);
+    expect((result.content as TextContent[])[0].text).toContain('escapes workingDirectory');
   });
 });

--- a/test/server.test.ts
+++ b/test/server.test.ts
@@ -1,7 +1,7 @@
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
-import { mkdirSync, mkdtempSync, rmSync, unlinkSync, writeFileSync } from 'fs';
+import { mkdirSync, mkdtempSync, rmSync, symlinkSync, unlinkSync, writeFileSync } from 'fs';
 import { tmpdir } from 'os';
 import { join } from 'path';
 import { fileURLToPath } from 'url';
@@ -20,6 +20,7 @@ import { spawnSync } from 'child_process';
 import {
   ALLOWED_DIRS,
   buildListTestsCmd,
+  formatStartupBanner,
   isInside,
   loadPackageMeta,
   parseAllowedDirs,
@@ -1346,5 +1347,285 @@ describe('get_test_attachment — path-traversal defense', () => {
     });
     expect(result.isError).toBe(true);
     expect((result.content as TextContent[])[0].text).toContain('escapes workingDirectory');
+  });
+});
+
+describe('workingDirectory — existence check (AC9)', () => {
+  beforeEach(() => spawnSyncMock.mockClear());
+
+  // Acceptance criterion: a nonexistent workingDirectory that would otherwise
+  // pass the allowlist must be rejected with a specific error. Without the
+  // existence check, Playwright spawns against a missing cwd and ENOENT
+  // surfaces as a generic "Failed to spawn" — the silent fall-through the
+  // issue explicitly forbids.
+  it('rejects a nonexistent workingDirectory with a dedicated error and no spawn', async () => {
+    const result = await client.callTool({
+      name: 'run_tests',
+      arguments: { workingDirectory: 'test/fixtures/does-not-exist-xyzzy' },
+    });
+    expect(result.isError).toBe(true);
+    const text = (result.content as TextContent[])[0].text;
+    expect(text).toContain('does not exist');
+    expect(text).not.toContain('Failed to spawn');
+    expect(spawnSyncMock).not.toHaveBeenCalled();
+  });
+
+  it('rejects a workingDirectory that exists but is a file, not a directory', async () => {
+    // The fixture results.json file exists under the allowlist; pointing at it
+    // as a "directory" must be rejected with a file-vs-dir specific error.
+    const filePath = fileURLToPath(
+      new URL('./fixtures/test-results/results.json', import.meta.url)
+    );
+    const result = await client.callTool({
+      name: 'run_tests',
+      arguments: { workingDirectory: filePath },
+    });
+    expect(result.isError).toBe(true);
+    const text = (result.content as TextContent[])[0].text;
+    expect(text).toContain('not a directory');
+    expect(spawnSyncMock).not.toHaveBeenCalled();
+  });
+});
+
+describe('workingDirectory — positive acceptance on the other three tools (AC5)', () => {
+  beforeEach(() => spawnSyncMock.mockClear());
+
+  // AC5 says the parameter is accepted by list_tests, get_failed_tests, and
+  // get_test_attachment with the same allowlist check. Negative paths are
+  // covered above; these are the positive counterparts.
+
+  it('list_tests accepts a workingDirectory under the allowlist and uses it as spawn cwd', async () => {
+    spawnSyncMock.mockReturnValueOnce({ status: 0, stdout: '{"suites":[]}', stderr: '' });
+    const data = parseResult(
+      await client.callTool({
+        name: 'list_tests',
+        arguments: { workingDirectory: 'test/fixtures' },
+      })
+    );
+    expect(data).toEqual({ count: 0, tests: [] });
+    const options = spawnSyncMock.mock.calls[0][2] as { cwd: string };
+    expect(options.cwd.endsWith('test/fixtures')).toBe(true);
+  });
+
+  it('get_failed_tests accepts a workingDirectory under the allowlist and returns the report', async () => {
+    const data = parseResult(
+      await client.callTool({
+        name: 'get_failed_tests',
+        arguments: { workingDirectory: 'test/fixtures' },
+      })
+    );
+    expect(data.failedCount).toBe(1);
+    expect(data.tests[0].title).toBe('login fails with wrong password');
+  });
+
+  it('get_test_attachment accepts a workingDirectory under the allowlist and returns content', async () => {
+    const data = parseResult(
+      await client.callTool({
+        name: 'get_test_attachment',
+        arguments: {
+          workingDirectory: 'test/fixtures',
+          testTitle: 'login fails with wrong password',
+          attachmentName: 'diagnosis',
+        },
+      })
+    );
+    expect(data.content).toContain('Button selector');
+  });
+});
+
+describe('formatStartupBanner — AC7 startup log', () => {
+  // Acceptance criterion: when PW_ALLOWED_DIRS is unset, the server surfaces
+  // "default — authorizing only launchCwd" so operators know what is allowed.
+  it('annotates the default case when PW_ALLOWED_DIRS is unset', () => {
+    const banner = formatStartupBanner('/some/launch/dir', ['/some/launch/dir'], undefined);
+    expect(banner).toContain('launchCwd=/some/launch/dir');
+    expect(banner).toContain('PW_ALLOWED_DIRS=/some/launch/dir');
+    expect(banner).toContain('default — authorizing only launchCwd');
+  });
+
+  it('annotates the default case when PW_ALLOWED_DIRS is the empty string', () => {
+    const banner = formatStartupBanner('/x', ['/x'], '');
+    expect(banner).toContain('default — authorizing only launchCwd');
+  });
+
+  it('omits the default annotation when the env var is set', () => {
+    const banner = formatStartupBanner('/x', ['/x', '/y'], '..');
+    expect(banner).toContain('PW_ALLOWED_DIRS=/x, /y');
+    expect(banner).not.toContain('default — authorizing only launchCwd');
+  });
+
+  it('terminates with a newline so it does not run into subsequent log lines', () => {
+    const banner = formatStartupBanner('/x', ['/x'], undefined);
+    expect(banner.endsWith('\n')).toBe(true);
+  });
+});
+
+// Symlink-based allowlist/attachment bypasses are the highest-severity risk
+// flagged in this PR's security review. These regressions exercise the
+// `realpathSync` canonicalization that closes the lexical-only containment
+// hole. Symlink creation needs elevated privileges on Windows, so each test
+// self-skips via `trySymlink` when creation fails.
+
+function trySymlink(target: string, path: string): boolean {
+  try {
+    symlinkSync(target, path);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+describe('workingDirectory — symlink-based allowlist bypass (security)', () => {
+  const fixtures = fileURLToPath(new URL('./fixtures', import.meta.url));
+  const symlinkPath = join(fixtures, 'symlink-escape');
+  let escapeTarget: string;
+
+  beforeAll(() => {
+    escapeTarget = mkdtempSync(join(tmpdir(), 'pw-report-mcp-symlink-target-'));
+  });
+
+  afterAll(() => {
+    rmSync(escapeTarget, { recursive: true, force: true });
+    try {
+      unlinkSync(symlinkPath);
+    } catch {
+      // absent or already cleaned
+    }
+  });
+
+  beforeEach(() => spawnSyncMock.mockClear());
+  afterEach(() => {
+    try {
+      unlinkSync(symlinkPath);
+    } catch {
+      // absent
+    }
+  });
+
+  // Lexical isInside() passes because the symlink's path is literally under
+  // the allowlist (repo root). Without realpathSync canonicalization, spawnSync
+  // would chdir to the target and Playwright would load a malicious
+  // playwright.config.ts from there. The fix is to reject such paths.
+  it('rejects a workingDirectory that is a symlink escaping the allowlist', async () => {
+    if (!trySymlink(escapeTarget, symlinkPath)) {
+      console.warn('[test] symlinkSync unavailable — skipping');
+      return;
+    }
+    const result = await client.callTool({
+      name: 'run_tests',
+      arguments: { workingDirectory: 'test/fixtures/symlink-escape' },
+    });
+    expect(result.isError).toBe(true);
+    const text = (result.content as TextContent[])[0].text;
+    expect(text).toContain('resolves via symlink');
+    expect(text).toContain('PW_ALLOWED_DIRS');
+    expect(spawnSyncMock).not.toHaveBeenCalled();
+  });
+
+  // A symlink whose target is still inside the allowlist (e.g. a convenience
+  // link within the same project) must continue to work.
+  it('accepts a symlink whose target is inside the allowlist', async () => {
+    const innerTarget = join(fixtures);
+    if (!trySymlink(innerTarget, symlinkPath)) {
+      console.warn('[test] symlinkSync unavailable — skipping');
+      return;
+    }
+    await client.callTool({
+      name: 'run_tests',
+      arguments: { workingDirectory: 'test/fixtures/symlink-escape' },
+    });
+    expect(spawnSyncMock).toHaveBeenCalledTimes(1);
+    const options = spawnSyncMock.mock.calls[0][2] as { cwd: string };
+    // cwd is canonicalized — matches the target, not the symlink path.
+    expect(options.cwd).toBe(innerTarget);
+  });
+});
+
+describe('get_test_attachment — symlink-based exfiltration (security)', () => {
+  const fixtures = fileURLToPath(new URL('./fixtures', import.meta.url));
+  const attachmentSymlinkPath = join(fixtures, 'test-results', 'sneaky.txt');
+  let secretPath: string;
+
+  beforeAll(() => {
+    // A secret file OUTSIDE the working directory (test/fixtures). Represents
+    // anything the MCP process could otherwise read — ~/.ssh/id_rsa, .env, etc.
+    const secretDir = mkdtempSync(join(tmpdir(), 'pw-report-mcp-secret-'));
+    secretPath = join(secretDir, 'id_rsa');
+    writeFileSync(secretPath, '-----BEGIN PRIVATE KEY-----\nSECRET\n-----END PRIVATE KEY-----\n');
+  });
+
+  afterAll(() => {
+    rmSync(secretPath, { force: true });
+    rmSync(join(secretPath, '..'), { recursive: true, force: true });
+  });
+
+  afterEach(() => {
+    writeDefaultReport();
+    try {
+      unlinkSync(attachmentSymlinkPath);
+    } catch {
+      // absent
+    }
+  });
+
+  // The attacker-controlled results.json declares a text attachment whose
+  // path is a symlink pointing at a secret file outside the working dir.
+  // Without canonicalizing the attachment path before readFileSync, the
+  // server would follow the symlink and return the secret contents.
+  it('rejects an attachment whose path is a symlink escaping workingDirectory', async () => {
+    if (!trySymlink(secretPath, attachmentSymlinkPath)) {
+      console.warn('[test] symlinkSync unavailable — skipping');
+      return;
+    }
+    writeCustomReport({
+      suites: [
+        {
+          title: 'x.spec.ts',
+          file: 'tests/x.spec.ts',
+          specs: [
+            {
+              title: 'symlink test',
+              file: 'tests/x.spec.ts',
+              line: 1,
+              ok: false,
+              tests: [
+                {
+                  projectName: 'Chromium',
+                  status: 'unexpected',
+                  results: [
+                    {
+                      status: 'failed',
+                      duration: 10,
+                      attachments: [
+                        {
+                          name: 'diag',
+                          contentType: 'text/plain',
+                          path: attachmentSymlinkPath,
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+      stats: { expected: 0, unexpected: 1, skipped: 0, duration: 10 },
+    });
+
+    const result = await client.callTool({
+      name: 'get_test_attachment',
+      arguments: {
+        workingDirectory: 'test/fixtures',
+        testTitle: 'symlink test',
+        attachmentName: 'diag',
+      },
+    });
+    expect(result.isError).toBe(true);
+    const text = (result.content as TextContent[])[0].text;
+    expect(text).toContain('resolves via symlink');
+    expect(text).toContain('escapes workingDirectory');
+    expect(text).not.toContain('BEGIN PRIVATE KEY');
   });
 });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -11,7 +11,12 @@ export default defineConfig({
       'test/fixtures/pw-project/**',
     ],
     env: {
-      PW_DIR: fileURLToPath(new URL('./test/fixtures', import.meta.url)),
+      // Default allowlist (unset → ".") authorizes only the repo root, which
+      // vitest uses as its cwd. Pin results.json to the fixture setup.ts writes
+      // so tools read it regardless of the per-call workingDirectory.
+      PW_RESULTS_FILE: fileURLToPath(
+        new URL('./test/fixtures/test-results/results.json', import.meta.url)
+      ),
     },
     coverage: {
       provider: 'v8',


### PR DESCRIPTION
## Summary

- Replace the `PW_DIR` env var with a per-call `workingDirectory` parameter on all four tools (`run_tests`, `list_tests`, `get_failed_tests`, `get_test_attachment`), unlocking multi-worktree workflows from a single long-lived MCP session.
- Gate the parameter with a `PW_ALLOWED_DIRS` allowlist (default `"."` = launch dir only) using a segment-level containment check so sibling-prefix bypasses (`/a/b` vs `/a/b-evil`) are rejected.
- Defense-in-depth on `get_test_attachment`: refuse to read any attachment whose recorded path escapes the resolved `workingDirectory` via `..` or an absolute path pointing elsewhere.

## Breaking change

`PW_DIR` is removed. Migration: either launch the MCP client from inside the Playwright project directory (default `workingDirectory: "."` works, zero config), or pass `workingDirectory` per call and set `PW_ALLOWED_DIRS` to authorize the target directories.

## Test plan

- [x] `npm test` — 71 tests pass (added 22 covering the new behavior: `isInside` segment match, `parseAllowedDirs` relative-resolution, allowlist gate on all four tools, sibling-name bypass rejection, attachment traversal rejection for both relative `..` and absolute paths)
- [x] `npm run build` clean
- [x] `npm run format:check` clean
- [x] Branch coverage 92.37% (threshold 85%)
- [x] Manual smoke test against the dist build from a launch cwd that differs from the target worktree

Closes #78
