### PR TITLE
#80 chore: bump to 3.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "playwright-report-mcp",
-  "version": "2.0.2",
+  "version": "3.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "playwright-report-mcp",
-      "version": "2.0.2",
+      "version": "3.0.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "playwright-report-mcp",
-  "version": "2.0.2",
+  "version": "3.0.0",
   "mcpName": "io.github.hubertgajewski/playwright-report-mcp",
   "description": "MCP server for running Playwright tests and reading structured results — designed for AI agents doing test failure analysis",
   "type": "module",

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/hubertgajewski/playwright-report-mcp",
     "source": "github"
   },
-  "version": "2.0.2",
+  "version": "3.0.0",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "playwright-report-mcp",
-      "version": "2.0.2",
+      "version": "3.0.0",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
## Summary

Bump all three version fields to `3.0.0` per the release ritual in CLAUDE.md:

- `package.json.version` → `3.0.0`
- `server.json.version` → `3.0.0`
- `server.json.packages[0].version` → `3.0.0`

`package-lock.json` is updated automatically (the two self-references to the project version).

## Why `3.0.0`

#78 (merged as #79) removed the `PW_DIR` env var and replaced it with a per-call `workingDirectory` parameter gated by `PW_ALLOWED_DIRS` — a SemVer-major breaking change. Current `main` is at `2.0.2`; next release ships as `3.0.0`.

## Release-notes blurb (paste into GitHub Release)

> **Breaking:** `PW_DIR` env var removed. Either launch the MCP client from inside the Playwright project directory (zero-config, default `workingDirectory: "."` works), or pass `workingDirectory` per call and set `PW_ALLOWED_DIRS` to authorize the target directories.

## Test plan

- [x] All three version fields match (`3.0.0`)
- [x] `package-lock.json` self-references updated
- [x] `npm run format:check` clean
- [x] After merge: tag `v3.0.0` → draft release → publish; `publish-npm.yml` + `publish-mcp.yml` run successfully
- [x] `3.0.0` appears on npm and registry.modelcontextprotocol.io

Closes #80
