### PR TITLE
#42 test: in-repo e2e suite driving MCP server over StdioClientTransport

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,7 @@ jobs:
 
   e2e:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6

--- a/test/fixtures/pw-project/.gitignore
+++ b/test/fixtures/pw-project/.gitignore
@@ -1,1 +1,3 @@
+node_modules/
 playwright-report/
+test-results/


### PR DESCRIPTION
## Summary

Two polish improvements on top of the e2e infrastructure already present on `main` (landed via #47):

- **CI `timeout-minutes: 15`** — guards the e2e job against hangs; individual test timeout is 3 min so 15 min at the job level is a safe ceiling. Previously the job inherited GitHub Actions' default of 6 hours.
- **Fixture `.gitignore` self-contained** — adds `node_modules/` and `test-results/` to `test/fixtures/pw-project/.gitignore` so the fixture is self-contained. The root `.gitignore` already covers them, but having them locally satisfies the acceptance criteria for isolation and is more portable if the fixture is ever copied standalone.

Closes #42

## Context

The full e2e suite (test/e2e.test.ts, fixture project, vitest.e2e.config.ts, CI e2e job, test:e2e script) was merged in #47. This PR closes out the remaining minor items surfaced by a post-merge review.

## Test plan

- [x] `npm run build && npm test` — all 103 unit tests pass
- [x] Pre-push `/review` — findings addressed before push
- [x] Post-PR `/review` — description updated to reflect actual diff scope

https://claude.ai/code/session_01Lg2gDsRCn2ASHMeLtMfwRB
