### PR TITLE
#86 chore: bump to 3.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "playwright-report-mcp",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "playwright-report-mcp",
-      "version": "3.0.0",
+      "version": "3.1.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "playwright-report-mcp",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "mcpName": "io.github.hubertgajewski/playwright-report-mcp",
   "description": "MCP server for running Playwright tests and reading structured results — designed for AI agents doing test failure analysis",
   "type": "module",

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/hubertgajewski/playwright-report-mcp",
     "source": "github"
   },
-  "version": "3.0.0",
+  "version": "3.1.0",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "playwright-report-mcp",
-      "version": "3.0.0",
+      "version": "3.1.0",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
Closes #86.

## Summary

Bumps all three version fields from `3.0.0` → `3.1.0`, reflecting the additive
run_tests CLI flag additions that landed in #85 (`bfa7b3d`). Pure chore —
no code or docs beyond the version fields.

Per the repo's [Cutting a release](https://github.com/hubertgajewski/playwright-report-mcp/blob/main/README.md#cutting-a-release)
section, the tag verification in `release.yml` requires all three fields to
match the pushed tag, so they're bumped together in a single commit.

## Why 3.1.0 (minor)

#85 added 6 new optional input fields to `run_tests` (`updateSnapshots`,
`headed`, `workers`, `retries`, `maxFailures`, `trace`). Additive, no renames,
no removals, no behavior change for existing callers — textbook MINOR under
semver. MAJOR would overstate it; PATCH understates it.

## Test plan

- [x] `package.json` `version` = `3.1.0`
- [x] `server.json` top-level `version` = `3.1.0`
- [x] `server.json` `packages[0].version` = `3.1.0`
- [x] `package-lock.json` synced via `npm install --package-lock-only`
- [x] `npm ci` clean
- [x] `npm run build` clean
- [x] `npm test` — 118 passing
- [x] `npm run format:check` clean
- [ ] After merge: tag `v3.1.0` and push — fires `release.yml` (GitHub Release +
      npm publish via OIDC) and `publish-mcp.yml` (MCP registry)
