### PR TITLE
#42 test: tighten e2e assertions — exitCode, stats.unexpected, failure details

### DIFF
--- a/test/e2e.test.ts
+++ b/test/e2e.test.ts
@@ -49,6 +49,14 @@ if (SKIP) {
 }
 
 type TextContent = { type: 'text'; text: string };
+type FailingTest = {
+  title: string;
+  failures: Array<{
+    status: string;
+    error: string | null;
+    attachments: Array<{ name: string; path?: string }>;
+  }>;
+};
 
 let client: Client;
 
@@ -138,18 +146,29 @@ describe.skipIf(SKIP)('MCP server e2e — fixture Playwright project', () => {
         const failing = (runData.tests as Array<{ ok: boolean }>).filter((t) => !t.ok);
         expect(failing.length).toBeGreaterThan(0);
       });
+
+      it('exits non-zero and reflects failure count in stats when the run has failures', () => {
+        expect(runData.exitCode).not.toBe(0);
+        expect((runData.stats as { unexpected: number }).unexpected).toBeGreaterThan(0);
+      });
     });
 
     describe('get_failed_tests', () => {
-      it('surfaces the deliberately failing spec', async () => {
+      it('surfaces the deliberately failing spec with error details and attachment path', async () => {
         const data = parseResult(
           await client.callTool({ name: 'get_failed_tests', arguments: {} })
         );
         expect(data.failedCount).toBeGreaterThan(0);
-        const failing = (data.tests as Array<{ title: string }>).find((t) =>
+        const failing = (data.tests as FailingTest[]).find((t) =>
           t.title.includes('deliberately fails')
         );
         expect(failing).toBeDefined();
+        expect(failing!.failures.length).toBeGreaterThan(0);
+        expect(failing!.failures[0].status).toBe('failed');
+        expect(failing!.failures[0].error).toBeTruthy();
+        const att = failing!.failures[0].attachments.find((a) => a.name === 'error-details');
+        expect(att).toBeDefined();
+        expect(att!.path).toBeTruthy();
       });
     });
 
@@ -171,7 +190,7 @@ describe.skipIf(SKIP)('MCP server e2e — fixture Playwright project', () => {
     // Runs AFTER get_failed_tests and get_test_attachment to avoid overwriting
     // results.json while those tools still need to read it.
     describe('run_tests timeout parameter', () => {
-      it('accepts the timeout parameter without error', async () => {
+      it('accepts the timeout parameter without error and exits 0 for a passing spec', async () => {
         const data = parseResult(
           await client.callTool({
             name: 'run_tests',
@@ -179,6 +198,7 @@ describe.skipIf(SKIP)('MCP server e2e — fixture Playwright project', () => {
           })
         );
         expect(typeof data.exitCode).toBe('number');
+        expect(data.exitCode).toBe(0);
         expect(data.stats).toBeDefined();
       }, 60_000);
     });


### PR DESCRIPTION
## Summary

Closes #42 — tightens the e2e assertions introduced for the in-repo end-to-end suite to cover behaviour that was previously only shape-checked:

- **`run_tests` (full run)** — new test verifies `exitCode` is non-zero and `stats.unexpected > 0` when the fixture's deliberately-failing spec is included in the run. Previously the suite only checked that `stats` had the right shape and that at least one `!ok` test existed, without asserting the failure was reflected in the exit code or counts.
- **`get_failed_tests`** — expands from "the failing spec appears in the list" to also assert `failures[0].status === 'failed'`, that `error` is non-null (the `expect(1).toBe(2)` assertion message is present), and that the `error-details` attachment has a populated `path` field. This fully exercises the issue's "surfaces the deliberate failure" criterion.
- **`run_tests` timeout parameter** — adds `expect(data.exitCode).toBe(0)` since the parameterised run targets only `tests/homepage.spec.ts`, which always passes. Pairs cleanly with the full-run assertion above.
- **Type hygiene** — `FailingTest` lifted to file scope alongside `TextContent` so it is available across tests rather than defined inline inside one `it` body.

All 9 e2e tests pass locally (including 8 pre-existing + the new sub-test), and the 118 unit tests are unchanged.

## Test plan

- [x] `npm run build` — TypeScript compiles without errors
- [x] `npm test` — 118 unit tests pass, sub-second
- [x] `PLAYWRIGHT_BROWSERS_PATH=/opt/pw-browsers npx vitest run --config vitest.e2e.config.ts` — 9/9 e2e tests pass against the fixture Playwright project
- [x] `npx prettier --check test/e2e.test.ts` — no formatting issues
- [x] Pre-push `/review` — findings addressed (type lift)

https://claude.ai/code/session_014rrCtxf2nbsvjPwV7NdXo6

---
_Generated by [Claude Code](https://claude.ai/code/session_014rrCtxf2nbsvjPwV7NdXo6)_