### PR TITLE
#95 ci: bump mcp-publisher to v1.7.8

### DIFF
--- a/.github/workflows/publish-mcp.yml
+++ b/.github/workflows/publish-mcp.yml
@@ -4,6 +4,11 @@ on:
   workflow_run:
     workflows: ['Release']
     types: [completed]
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: 'Release ref, tag, or commit SHA to publish to the MCP registry'
+        required: true
 
 permissions:
   contents: read
@@ -12,19 +17,24 @@ permissions:
 jobs:
   publish:
     # Only run when the upstream Release workflow succeeded AND was itself triggered
-    # by a tag push — skips manual or branch-push runs of the upstream workflow.
+    # by a tag push, or when explicitly retried with a release ref.
     if: >-
-      github.event.workflow_run.conclusion == 'success' &&
-      github.event.workflow_run.event == 'push'
+      github.event_name == 'workflow_dispatch' ||
+      (
+        github.event_name == 'workflow_run' &&
+        github.event.workflow_run.conclusion == 'success' &&
+        github.event.workflow_run.event == 'push'
+      )
     runs-on: ubuntu-latest
     env:
       MCP_REGISTRY_SEARCH_URL: https://registry.modelcontextprotocol.io/v0.1/servers
     steps:
       # workflow_run runs against the default branch by default, which may have drifted
-      # past the release commit. Pin checkout to the upstream workflow's commit SHA.
+      # past the release commit. Pin automatic publishes to the upstream workflow's
+      # commit SHA; manual retries check out the supplied release ref.
       - uses: actions/checkout@v6
         with:
-          ref: ${{ github.event.workflow_run.head_sha }}
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.ref || github.event.workflow_run.head_sha }}
 
       - name: Version-sync check
         run: |
@@ -65,9 +75,9 @@ jobs:
 
       - name: Install mcp-publisher (pinned, checksum-verified)
         env:
-          MCP_PUBLISHER_TAG: v1.6.0
+          MCP_PUBLISHER_TAG: v1.7.8
           MCP_PUBLISHER_ASSET: mcp-publisher_linux_amd64.tar.gz
-          MCP_PUBLISHER_SHA256: 2de4ac3bf5b2aa9b012291a6969f16e4a2e37b70baab7f066e06998823405d42
+          MCP_PUBLISHER_SHA256: 48230dbec85bd88a0d42977ef533cddda23235f0db4331b9263ce53b432cb75c
         run: |
           set -euo pipefail
           URL="https://github.com/modelcontextprotocol/registry/releases/download/${MCP_PUBLISHER_TAG}/${MCP_PUBLISHER_ASSET}"

--- a/.github/workflows/publish-mcp.yml
+++ b/.github/workflows/publish-mcp.yml
@@ -4,11 +4,6 @@ on:
   workflow_run:
     workflows: ['Release']
     types: [completed]
-  workflow_dispatch:
-    inputs:
-      ref:
-        description: 'Release ref, tag, or commit SHA to publish to the MCP registry'
-        required: true
 
 permissions:
   contents: read
@@ -17,24 +12,19 @@ permissions:
 jobs:
   publish:
     # Only run when the upstream Release workflow succeeded AND was itself triggered
-    # by a tag push, or when explicitly retried with a release ref.
+    # by a tag push — skips manual or branch-push runs of the upstream workflow.
     if: >-
-      github.event_name == 'workflow_dispatch' ||
-      (
-        github.event_name == 'workflow_run' &&
-        github.event.workflow_run.conclusion == 'success' &&
-        github.event.workflow_run.event == 'push'
-      )
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.event == 'push'
     runs-on: ubuntu-latest
     env:
       MCP_REGISTRY_SEARCH_URL: https://registry.modelcontextprotocol.io/v0.1/servers
     steps:
       # workflow_run runs against the default branch by default, which may have drifted
-      # past the release commit. Pin automatic publishes to the upstream workflow's
-      # commit SHA; manual retries check out the supplied release ref.
+      # past the release commit. Pin checkout to the upstream workflow's commit SHA.
       - uses: actions/checkout@v6
         with:
-          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.ref || github.event.workflow_run.head_sha }}
+          ref: ${{ github.event.workflow_run.head_sha }}
 
       - name: Version-sync check
         run: |


### PR DESCRIPTION
## Summary

- Bump the pinned MCP registry publisher from `v1.6.0` to `v1.7.8`.
- Update the checksum for the `mcp-publisher_linux_amd64.tar.gz` asset.
- Leave the `publish-mcp.yml` trigger and publish flow unchanged.

Closes #95

## Test Plan

- [x] `npm run format:check`
- [x] `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/publish-mcp.yml'); puts 'yaml ok'"`
- [x] `shasum -a 256 /private/tmp/mcp-publisher-v1.7.8.tar.gz`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated internal build tool versions used in the publishing pipeline to maintain compatibility and security standards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->