### PR TITLE
#97 chore: bump to 3.1.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "playwright-report-mcp",
-  "version": "3.1.1",
+  "version": "3.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "playwright-report-mcp",
-      "version": "3.1.1",
+      "version": "3.1.2",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "playwright-report-mcp",
-  "version": "3.1.1",
+  "version": "3.1.2",
   "mcpName": "io.github.hubertgajewski/playwright-report-mcp",
   "description": "MCP server for running Playwright tests and reading structured results — designed for AI agents doing test failure analysis",
   "type": "module",

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/hubertgajewski/playwright-report-mcp",
     "source": "github"
   },
-  "version": "3.1.1",
+  "version": "3.1.2",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "playwright-report-mcp",
-      "version": "3.1.1",
+      "version": "3.1.2",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
Summary
- Bump package metadata from 3.1.1 to 3.1.2.
- Keep server.json top-level and package versions aligned for the MCP registry release flow.
- Keep package-lock.json root package version entries aligned with package.json.

Closes #97

Test plan
- [x] npm run build
- [x] npm test
- [x] npm run format:check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version updated to 3.1.2

<!-- end of auto-generated comment: release notes by coderabbit.ai -->