### PR TITLE
#104 chore: bump to 3.1.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "playwright-report-mcp",
-  "version": "3.1.3",
+  "version": "3.1.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "playwright-report-mcp",
-      "version": "3.1.3",
+      "version": "3.1.4",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "playwright-report-mcp",
-  "version": "3.1.3",
+  "version": "3.1.4",
   "mcpName": "io.github.hubertgajewski/playwright-report-mcp",
   "description": "MCP server for running Playwright tests and reading structured results — designed for AI agents doing test failure analysis",
   "type": "module",

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/hubertgajewski/playwright-report-mcp",
     "source": "github"
   },
-  "version": "3.1.3",
+  "version": "3.1.4",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "playwright-report-mcp",
-      "version": "3.1.3",
+      "version": "3.1.4",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
Closes #104

## Summary
- Bump package metadata from `3.1.3` to `3.1.4`.
- Keep `package.json`, root `package-lock.json`, and `server.json` release metadata in sync.

## Test plan
- [x] `package.json` `version` equals `3.1.4`
- [x] `package-lock.json` root version entries equal `3.1.4`
- [x] `server.json` top-level `version` equals `3.1.4`
- [x] `server.json` `packages[0].version` equals `3.1.4`
- [x] `npm run build`
- [x] `npm test`
- [x] `npx prettier --check package.json package-lock.json server.json`
- [x] GitHub-hosted CI passes

Note: local full `npm run format:check` still reports the unrelated untracked `CLAUDE.md`; it is not part of this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version updated to 3.1.4

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hubertgajewski/playwright-report-mcp/pull/105)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->