### PR TITLE
#110 Add test run status polling

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,16 +179,16 @@ Runs the Playwright test suite and returns structured pass/fail results.
 
 Returns: exit code, run stats, and a summary of all tests with status, duration, and error per project.
 
-When `wait` is `false`, returns immediately with `runId`, process metadata, output tails, and current `results.json` status. Poll `get_run_status` with that `runId` until `state` is `completed`, `failed`, or `timedOut`.
+When `wait` is `false`, returns immediately with `runId`, process metadata, output tails, and current `results.json` status. Poll `get_run_status` with that `runId` until `state` is `completed`, `failed`, or `timedOut`. The server allows one active tracked run per working directory, caps active tracked runs globally, and keeps a bounded history of recent terminal runs, so very old `runId` values can expire.
 
 ### `get_run_status`
 
 Returns the current status for a non-blocking run started by `run_tests` with `wait: false`.
 
-| Input              | Type              | Description                                                                                                  |
-| ------------------ | ----------------- | ------------------------------------------------------------------------------------------------------------ |
-| `runId`            | string (optional) | Run identifier returned by `run_tests wait=false`. When present, this selects a specific tracked run.        |
-| `workingDirectory` | string (optional) | Used only when `runId` is omitted. Returns the latest tracked run for that directory, or `idle` if no match. |
+| Input              | Type              | Description                                                                                                                                                        |
+| ------------------ | ----------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `runId`            | string (optional) | Run identifier returned by `run_tests wait=false`. When present, this selects a specific tracked run.                                                              |
+| `workingDirectory` | string (optional) | When `runId` is omitted, returns the latest tracked run for that directory, or `idle` if no match. When supplied with `runId`, it must match that run's directory. |
 
 If both fields are omitted, `workingDirectory` defaults to `"."`. If no run is tracked for the resolved directory, the tool returns `state: "idle"` plus `results.json` metadata and last parsed stats when readable. It does not process-scan for external `npx playwright test` commands that were not started through this MCP server.
 
@@ -284,7 +284,7 @@ Set `PW_RESULTS_FILE` if your `playwright.config.ts` writes the report to a non-
 
 ### Multi-worktree support
 
-`run_tests`, `list_tests`, `get_failed_tests`, and `get_test_attachment` all accept an optional `workingDirectory` parameter — absolute, or relative to the MCP server's launch directory. `get_run_status` also accepts `workingDirectory` when `runId` is omitted; when `runId` is supplied, the run already records the resolved working directory. This lets a single long-lived MCP session drive tests across multiple git worktrees without restarting.
+`run_tests`, `list_tests`, `get_failed_tests`, and `get_test_attachment` all accept an optional `workingDirectory` parameter — absolute, or relative to the MCP server's launch directory. `get_run_status` also accepts `workingDirectory` when `runId` is omitted; when `runId` is supplied, any supplied `workingDirectory` must resolve to that run's recorded directory. This lets a single long-lived MCP session drive tests across multiple git worktrees without restarting.
 
 Because a Playwright config is a Node module that executes on `playwright test` startup, the server guards the parameter with an allowlist. Callers that point `workingDirectory` at a directory outside `PW_ALLOWED_DIRS` get a structured error and no child process is spawned.
 
@@ -366,7 +366,7 @@ npm test          # run tests once
 npm run test:watch  # watch mode
 ```
 
-Tests use [Vitest](https://vitest.dev/) and cover the `collectSpecs` helper (unit) and all four MCP tools via `InMemoryTransport` (integration). No build step or Playwright installation required to run the test suite.
+Tests use [Vitest](https://vitest.dev/) and cover the `collectSpecs` helper (unit) and all MCP tools via `InMemoryTransport` (integration). No build step or Playwright installation required to run the test suite.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ Tested with **Claude Code (CLI)**. Should work with any MCP-compatible client th
 
 ## Tools
 
-All four tools accept an optional `workingDirectory` parameter — see [Multi-worktree support](#multi-worktree-support).
+The project-scoped tools accept an optional `workingDirectory` parameter — see [Multi-worktree support](#multi-worktree-support). `get_run_status` can use either a `runId` from `run_tests` with `wait: false`, or a `workingDirectory` lookup for the latest tracked run.
 
 ### `run_tests`
 
@@ -169,6 +169,7 @@ Runs the Playwright test suite and returns structured pass/fail results.
 | `browser`          | enum (optional)    | `Chromium`, `Firefox`, `Webkit`, `Mobile Chrome`, `Mobile Safari`                                                                                                                                                                                               |
 | `tag`              | string (optional)  | Tag filter, e.g. `@smoke`                                                                                                                                                                                                                                       |
 | `timeout`          | integer (optional) | Timeout in milliseconds for the whole test run. Defaults to `300000` (5 min). Use a larger value for long suites or a smaller one to fail fast. When the run is killed by this timeout, the tool returns an explicit error rather than a generic non-zero exit. |
+| `wait`             | boolean (optional) | Wait for completion before returning. Defaults to `true`. Set to `false` to start a background run and poll it with `get_run_status`.                                                                                                                           |
 | `updateSnapshots`  | enum (optional)    | Update snapshot baselines. One of `all`, `changed`, `missing`, `none`. Playwright's default is `missing`; `changed` updates differing + missing. Omit to leave existing baselines alone.                                                                        |
 | `headed`           | boolean (optional) | Run with a visible browser window. Omitting or setting `false` leaves `playwright.config.ts` intact — Playwright has no `--no-headed` flag, so `false` does not force headless when the config sets headed.                                                     |
 | `workers`          | integer (optional) | Number of parallel workers. Positive integer only; the `"50%"` string form is not yet supported.                                                                                                                                                                |
@@ -177,6 +178,21 @@ Runs the Playwright test suite and returns structured pass/fail results.
 | `trace`            | enum (optional)    | Force Playwright tracing mode, overriding `playwright.config.ts`. One of `on`, `off`, `on-first-retry`, `on-all-retries`, `retain-on-failure`, `retain-on-first-failure`, `retain-on-failure-and-retries`.                                                      |
 
 Returns: exit code, run stats, and a summary of all tests with status, duration, and error per project.
+
+When `wait` is `false`, returns immediately with `runId`, process metadata, output tails, and current `results.json` status. Poll `get_run_status` with that `runId` until `state` is `completed`, `failed`, or `timedOut`.
+
+### `get_run_status`
+
+Returns the current status for a non-blocking run started by `run_tests` with `wait: false`.
+
+| Input              | Type              | Description                                                                                                  |
+| ------------------ | ----------------- | ------------------------------------------------------------------------------------------------------------ |
+| `runId`            | string (optional) | Run identifier returned by `run_tests wait=false`. When present, this selects a specific tracked run.        |
+| `workingDirectory` | string (optional) | Used only when `runId` is omitted. Returns the latest tracked run for that directory, or `idle` if no match. |
+
+If both fields are omitted, `workingDirectory` defaults to `"."`. If no run is tracked for the resolved directory, the tool returns `state: "idle"` plus `results.json` metadata and last parsed stats when readable. It does not process-scan for external `npx playwright test` commands that were not started through this MCP server.
+
+Returns: run state, tracking flag, pid, timestamps, elapsed duration, timeout, command metadata, stdout/stderr tails, exit code, signal, spawn/timeout error when present, `results.json` path/existence/mtime/size/freshness, and parsed report stats when the report was updated after the run started.
 
 ### `get_failed_tests`
 
@@ -268,7 +284,7 @@ Set `PW_RESULTS_FILE` if your `playwright.config.ts` writes the report to a non-
 
 ### Multi-worktree support
 
-`run_tests`, `list_tests`, `get_failed_tests`, and `get_test_attachment` all accept an optional `workingDirectory` parameter — absolute, or relative to the MCP server's launch directory. This lets a single long-lived MCP session drive tests across multiple git worktrees without restarting.
+`run_tests`, `list_tests`, `get_failed_tests`, and `get_test_attachment` all accept an optional `workingDirectory` parameter — absolute, or relative to the MCP server's launch directory. `get_run_status` also accepts `workingDirectory` when `runId` is omitted; when `runId` is supplied, the run already records the resolved working directory. This lets a single long-lived MCP session drive tests across multiple git worktrees without restarting.
 
 Because a Playwright config is a Node module that executes on `playwright test` startup, the server guards the parameter with an allowlist. Callers that point `workingDirectory` at a directory outside `PW_ALLOWED_DIRS` get a structured error and no child process is spawned.
 

--- a/index.ts
+++ b/index.ts
@@ -2,6 +2,7 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import { spawn, spawnSync } from 'child_process';
+import { randomUUID } from 'crypto';
 import { readFileSync, realpathSync, statSync } from 'fs';
 import { delimiter, dirname, isAbsolute, join, relative, resolve } from 'path';
 import { fileURLToPath } from 'url';
@@ -99,33 +100,42 @@ interface PwReport {
   };
 }
 
-type RunState = 'idle' | 'running' | 'completed' | 'failed' | 'timedOut';
+type TrackedRunState = 'running' | 'completed' | 'failed' | 'timedOut';
+
+interface ResultsFileStatus {
+  path: string;
+  exists: boolean;
+  mtimeMs: number | null;
+  size: number | null;
+  updatedAfterStart: boolean | null;
+}
 
 interface TrackedRun {
   id: string;
   cwd: string;
   cmd: string[];
   pid: number | null;
-  state: RunState;
+  state: TrackedRunState;
   startedAt: string;
   startedAtMs: number;
   completedAt: string | null;
   timeoutMs: number;
   stdoutTail: string;
   stderrTail: string;
-  stdout: string;
-  stderr: string;
   exitCode: number | null;
   signal: NodeJS.Signals | null;
   error: string | null;
+  resultsFile: ResultsFileStatus | null;
+  reportStats: PwReport['stats'] | null;
 }
 
 // ---------- helpers ----------
 
-const RUN_OUTPUT_LIMIT = 10 * 1024 * 1024;
+const MAX_ACTIVE_RUNS = 4;
+const MAX_TRACKED_RUNS = 50;
+const KILL_ESCALATION_MS = 5_000;
 const RUN_TAIL_LIMIT = 20_000;
 const runs = new Map<string, TrackedRun>();
-let nextRunId = 0;
 
 /**
  * Segment-level containment check. Returns true when `child` equals `parent`
@@ -237,7 +247,43 @@ function appendLimited(current: string, chunk: string, limit: number): string {
 }
 
 function nextStableRunId(): string {
-  return `run-${Date.now()}-${++nextRunId}`;
+  return `run-${randomUUID()}`;
+}
+
+function errorMessage(e: unknown): string {
+  return e instanceof Error ? e.message : String(e);
+}
+
+function activeRuns(): TrackedRun[] {
+  return Array.from(runs.values()).filter((run) => run.completedAt === null);
+}
+
+function startRunError(cwd: string): string | null {
+  const active = activeRuns();
+  const activeForDir = active.find((run) => run.cwd === cwd);
+  if (activeForDir) {
+    return (
+      `A Playwright run is already running for workingDirectory "${cwd}" ` +
+      `(runId: ${activeForDir.id}). Poll get_run_status before starting another run there.`
+    );
+  }
+
+  const activeCount = active.length;
+  if (activeCount >= MAX_ACTIVE_RUNS) {
+    return (
+      `Too many active Playwright runs (${activeCount}). ` +
+      `Wait for one to finish before starting another tracked run.`
+    );
+  }
+
+  return null;
+}
+
+function evictOldTrackedRuns() {
+  for (const run of runs.values()) {
+    if (runs.size <= MAX_TRACKED_RUNS) return;
+    if (run.completedAt !== null) runs.delete(run.id);
+  }
 }
 
 function summarizeReport(report: PwReport, exitCode: number) {
@@ -261,6 +307,25 @@ function summarizeReport(report: PwReport, exitCode: number) {
   return { exitCode, stats: report.stats, tests: summary };
 }
 
+function captureRunReport(run: TrackedRun) {
+  run.resultsFile = resultsFileStatus(run.cwd, run.startedAtMs);
+  run.reportStats = run.resultsFile.updatedAfterStart
+    ? (readLastReport(run.cwd)?.stats ?? null)
+    : null;
+}
+
+function signalProcessTree(child: ReturnType<typeof spawn>, signal: NodeJS.Signals) {
+  if (child.pid && process.platform !== 'win32') {
+    try {
+      process.kill(-child.pid, signal);
+      return;
+    } catch {
+      // Fall back to signaling the direct child when process-group signaling is unavailable.
+    }
+  }
+  child.kill(signal);
+}
+
 function startTrackedRun(cmd: string[], cwd: string, timeoutMs: number): TrackedRun {
   const now = Date.now();
   const run: TrackedRun = {
@@ -275,45 +340,50 @@ function startTrackedRun(cmd: string[], cwd: string, timeoutMs: number): Tracked
     timeoutMs,
     stdoutTail: '',
     stderrTail: '',
-    stdout: '',
-    stderr: '',
     exitCode: null,
     signal: null,
     error: null,
+    resultsFile: null,
+    reportStats: null,
   };
   runs.set(run.id, run);
+  evictOldTrackedRuns();
 
   let settled = false;
+  let timedOut = false;
   let child: ReturnType<typeof spawn>;
   let timeoutHandle: ReturnType<typeof setTimeout> | null = null;
+  let killEscalationHandle: ReturnType<typeof setTimeout> | null = null;
 
   const complete = () => {
     if (settled) return;
     settled = true;
     if (timeoutHandle) clearTimeout(timeoutHandle);
+    if (killEscalationHandle && !timedOut) clearTimeout(killEscalationHandle);
     run.completedAt = new Date().toISOString();
+    evictOldTrackedRuns();
   };
 
   const appendStdout = (chunk: unknown) => {
     const text = String(chunk);
-    run.stdout = appendLimited(run.stdout, text, RUN_OUTPUT_LIMIT);
     run.stdoutTail = appendLimited(run.stdoutTail, text, RUN_TAIL_LIMIT);
   };
 
   const appendStderr = (chunk: unknown) => {
     const text = String(chunk);
-    run.stderr = appendLimited(run.stderr, text, RUN_OUTPUT_LIMIT);
     run.stderrTail = appendLimited(run.stderrTail, text, RUN_TAIL_LIMIT);
   };
 
   try {
     child = spawn(cmd[0], cmd.slice(1), {
       cwd,
+      detached: process.platform !== 'win32',
       stdio: ['ignore', 'pipe', 'pipe'],
     });
   } catch (e) {
     run.state = 'failed';
-    run.error = `Failed to spawn Playwright: ${(e as Error).message}`;
+    run.error = `Failed to spawn Playwright: ${errorMessage(e)}`;
+    captureRunReport(run);
     complete();
     return run;
   }
@@ -322,32 +392,45 @@ function startTrackedRun(cmd: string[], cwd: string, timeoutMs: number): Tracked
   child.stdout?.on('data', appendStdout);
   child.stderr?.on('data', appendStderr);
   child.once('error', (e) => {
-    if (run.state !== 'timedOut') {
+    if (timedOut) {
+      run.state = 'timedOut';
+    } else {
       run.state = 'failed';
-      run.error = `Failed to spawn Playwright: ${(e as Error).message}`;
+      run.error = `Failed to spawn Playwright: ${errorMessage(e)}`;
     }
+    captureRunReport(run);
     complete();
   });
   child.once('close', (code, signal) => {
-    run.exitCode = code;
-    run.signal = signal;
-    if (run.state !== 'timedOut') {
-      run.state = code === 0 ? 'completed' : 'failed';
+    if (!settled) {
+      run.exitCode = code;
+      if (signal !== null) run.signal = signal;
     }
+    if (!settled) {
+      run.state = timedOut ? 'timedOut' : code === 0 ? 'completed' : 'failed';
+    }
+    if (!settled) captureRunReport(run);
     complete();
   });
 
   timeoutHandle = setTimeout(() => {
     if (settled) return;
-    run.state = 'timedOut';
+    timedOut = true;
     run.error = `Playwright test run exceeded the ${timeoutMs}ms timeout and was killed.`;
-    child.kill('SIGTERM');
+    signalProcessTree(child, 'SIGTERM');
+    if (settled) return;
+    killEscalationHandle = setTimeout(() => {
+      if (!timedOut) return;
+      if (!settled) run.signal = 'SIGKILL';
+      signalProcessTree(child, 'SIGKILL');
+    }, KILL_ESCALATION_MS);
+    killEscalationHandle.unref?.();
   }, timeoutMs);
 
   return run;
 }
 
-function resultsFileStatus(dir: string, startedAtMs?: number) {
+function resultsFileStatus(dir: string, startedAtMs?: number): ResultsFileStatus {
   const resultsPath = resultsFileFor(dir);
   const st = statSync(resultsPath, { throwIfNoEntry: false });
   const updatedAfterStart =
@@ -363,9 +446,13 @@ function resultsFileStatus(dir: string, startedAtMs?: number) {
 }
 
 function runStatus(run: TrackedRun) {
-  const resultsFile = resultsFileStatus(run.cwd, run.startedAtMs);
+  const resultsFile = run.resultsFile ?? resultsFileStatus(run.cwd, run.startedAtMs);
   const endedAtMs = run.completedAt ? Date.parse(run.completedAt) : Date.now();
-  const report = resultsFile.updatedAfterStart ? readLastReport(run.cwd) : null;
+  const stats =
+    run.reportStats ??
+    (run.state === 'running' && resultsFile.updatedAfterStart
+      ? (readLastReport(run.cwd)?.stats ?? null)
+      : null);
 
   return {
     runId: run.id,
@@ -387,7 +474,7 @@ function runStatus(run: TrackedRun) {
     signal: run.signal,
     error: run.error,
     resultsFile,
-    stats: report?.stats ?? null,
+    stats,
   };
 }
 
@@ -416,7 +503,7 @@ function latestRunForDir(cwd: string): TrackedRun | null {
   let latest: TrackedRun | null = null;
   for (const run of runs.values()) {
     if (run.cwd !== cwd) continue;
-    if (!latest || run.startedAtMs > latest.startedAtMs) latest = run;
+    latest = run;
   }
   return latest;
 }
@@ -525,6 +612,13 @@ const workingDirectoryField = z
     'Playwright project directory. Absolute or relative to the MCP server launch directory. Defaults to ".". Must be under PW_ALLOWED_DIRS.'
   );
 
+const runStatusWorkingDirectoryField = z
+  .string()
+  .optional()
+  .describe(
+    'Playwright project directory. Absolute or relative to the MCP server launch directory. Defaults to ".". Must be under PW_ALLOWED_DIRS. Used to find the latest tracked run when runId is omitted; when supplied with runId, it must resolve to that run working directory.'
+  );
+
 server.registerTool(
   'run_tests',
   {
@@ -626,6 +720,8 @@ server.registerTool(
 
     const effectiveTimeout = timeout ?? 300_000;
     if (wait === false) {
+      const startError = startRunError(wd.dir);
+      if (startError) return err(startError);
       const run = startTrackedRun(cmd, wd.dir, effectiveTimeout);
       return ok(runStatus(run));
     }
@@ -656,9 +752,9 @@ server.registerTool(
   'get_run_status',
   {
     description:
-      'Return status for a Playwright run. Pass runId for a specific background run, or omit it to inspect the latest tracked run for a workingDirectory.',
+      'Return status for a tracked Playwright run. Pass runId for a specific background run, or omit it to inspect the latest tracked run for a workingDirectory. If no tracked run exists, returns idle with current results.json metadata; it does not inspect unrelated OS processes.',
     inputSchema: {
-      workingDirectory: workingDirectoryField,
+      workingDirectory: runStatusWorkingDirectoryField,
       runId: z
         .string()
         .optional()
@@ -669,6 +765,15 @@ server.registerTool(
     if (runId) {
       const run = runs.get(runId);
       if (!run) return err(`Unknown runId: ${runId}`);
+      if (workingDirectory !== undefined) {
+        const wd = resolveWorkingDir(workingDirectory);
+        if ('error' in wd) return err(wd.error);
+        if (wd.dir !== run.cwd) {
+          return err(
+            `workingDirectory "${wd.dir}" does not match runId ${runId} workingDirectory "${run.cwd}".`
+          );
+        }
+      }
       return ok(runStatus(run));
     }
 
@@ -819,7 +924,7 @@ server.registerTool(
       tests = parseListJson(stdout);
     } catch (e) {
       return err(
-        `Failed to parse Playwright --list JSON output: ${(e as Error).message}\nstderr: ${result.stderr ?? ''}`
+        `Failed to parse Playwright --list JSON output: ${errorMessage(e)}\nstderr: ${result.stderr ?? ''}`
       );
     }
 

--- a/index.ts
+++ b/index.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
-import { spawnSync } from 'child_process';
+import { spawn, spawnSync } from 'child_process';
 import { readFileSync, realpathSync, statSync } from 'fs';
 import { delimiter, dirname, isAbsolute, join, relative, resolve } from 'path';
 import { fileURLToPath } from 'url';
@@ -99,7 +99,33 @@ interface PwReport {
   };
 }
 
+type RunState = 'idle' | 'running' | 'completed' | 'failed' | 'timedOut';
+
+interface TrackedRun {
+  id: string;
+  cwd: string;
+  cmd: string[];
+  pid: number | null;
+  state: RunState;
+  startedAt: string;
+  startedAtMs: number;
+  completedAt: string | null;
+  timeoutMs: number;
+  stdoutTail: string;
+  stderrTail: string;
+  stdout: string;
+  stderr: string;
+  exitCode: number | null;
+  signal: NodeJS.Signals | null;
+  error: string | null;
+}
+
 // ---------- helpers ----------
+
+const RUN_OUTPUT_LIMIT = 10 * 1024 * 1024;
+const RUN_TAIL_LIMIT = 20_000;
+const runs = new Map<string, TrackedRun>();
+let nextRunId = 0;
 
 /**
  * Segment-level containment check. Returns true when `child` equals `parent`
@@ -203,6 +229,196 @@ function runPlaywright(cmd: string[], cwd: string, timeoutMs: number) {
     timeout: timeoutMs,
     maxBuffer: 10 * 1024 * 1024,
   });
+}
+
+function appendLimited(current: string, chunk: string, limit: number): string {
+  const combined = current + chunk;
+  return combined.length > limit ? combined.slice(combined.length - limit) : combined;
+}
+
+function nextStableRunId(): string {
+  return `run-${Date.now()}-${++nextRunId}`;
+}
+
+function summarizeReport(report: PwReport, exitCode: number) {
+  const specs = collectSpecs(report.suites);
+  const summary = specs.map(({ spec: s, file }) => ({
+    title: s.title,
+    file,
+    ok: s.ok,
+    // results.at(-1) = final retry attempt — authoritative outcome when Playwright retries are configured
+    results: s.tests.map((t) => {
+      const last = t.results.at(-1);
+      return {
+        project: t.projectName,
+        status: last?.status ?? 'unknown',
+        duration: last?.duration ?? 0,
+        error: last?.error?.message ?? null,
+      };
+    }),
+  }));
+
+  return { exitCode, stats: report.stats, tests: summary };
+}
+
+function startTrackedRun(cmd: string[], cwd: string, timeoutMs: number): TrackedRun {
+  const now = Date.now();
+  const run: TrackedRun = {
+    id: nextStableRunId(),
+    cwd,
+    cmd,
+    pid: null,
+    state: 'running',
+    startedAt: new Date(now).toISOString(),
+    startedAtMs: now,
+    completedAt: null,
+    timeoutMs,
+    stdoutTail: '',
+    stderrTail: '',
+    stdout: '',
+    stderr: '',
+    exitCode: null,
+    signal: null,
+    error: null,
+  };
+  runs.set(run.id, run);
+
+  let settled = false;
+  let child: ReturnType<typeof spawn>;
+  let timeoutHandle: ReturnType<typeof setTimeout> | null = null;
+
+  const complete = () => {
+    if (settled) return;
+    settled = true;
+    if (timeoutHandle) clearTimeout(timeoutHandle);
+    run.completedAt = new Date().toISOString();
+  };
+
+  const appendStdout = (chunk: unknown) => {
+    const text = String(chunk);
+    run.stdout = appendLimited(run.stdout, text, RUN_OUTPUT_LIMIT);
+    run.stdoutTail = appendLimited(run.stdoutTail, text, RUN_TAIL_LIMIT);
+  };
+
+  const appendStderr = (chunk: unknown) => {
+    const text = String(chunk);
+    run.stderr = appendLimited(run.stderr, text, RUN_OUTPUT_LIMIT);
+    run.stderrTail = appendLimited(run.stderrTail, text, RUN_TAIL_LIMIT);
+  };
+
+  try {
+    child = spawn(cmd[0], cmd.slice(1), {
+      cwd,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+  } catch (e) {
+    run.state = 'failed';
+    run.error = `Failed to spawn Playwright: ${(e as Error).message}`;
+    complete();
+    return run;
+  }
+
+  run.pid = child.pid ?? null;
+  child.stdout?.on('data', appendStdout);
+  child.stderr?.on('data', appendStderr);
+  child.once('error', (e) => {
+    if (run.state !== 'timedOut') {
+      run.state = 'failed';
+      run.error = `Failed to spawn Playwright: ${(e as Error).message}`;
+    }
+    complete();
+  });
+  child.once('close', (code, signal) => {
+    run.exitCode = code;
+    run.signal = signal;
+    if (run.state !== 'timedOut') {
+      run.state = code === 0 ? 'completed' : 'failed';
+    }
+    complete();
+  });
+
+  timeoutHandle = setTimeout(() => {
+    if (settled) return;
+    run.state = 'timedOut';
+    run.error = `Playwright test run exceeded the ${timeoutMs}ms timeout and was killed.`;
+    child.kill('SIGTERM');
+  }, timeoutMs);
+
+  return run;
+}
+
+function resultsFileStatus(dir: string, startedAtMs?: number) {
+  const resultsPath = resultsFileFor(dir);
+  const st = statSync(resultsPath, { throwIfNoEntry: false });
+  const updatedAfterStart =
+    startedAtMs === undefined ? null : Boolean(st && st.mtimeMs >= startedAtMs);
+
+  return {
+    path: resultsPath,
+    exists: Boolean(st),
+    mtimeMs: st?.mtimeMs ?? null,
+    size: st?.size ?? null,
+    updatedAfterStart,
+  };
+}
+
+function runStatus(run: TrackedRun) {
+  const resultsFile = resultsFileStatus(run.cwd, run.startedAtMs);
+  const endedAtMs = run.completedAt ? Date.parse(run.completedAt) : Date.now();
+  const report = resultsFile.updatedAfterStart ? readLastReport(run.cwd) : null;
+
+  return {
+    runId: run.id,
+    state: run.state,
+    tracking: true,
+    pid: run.pid,
+    startedAt: run.startedAt,
+    completedAt: run.completedAt,
+    elapsedMs: Math.max(0, endedAtMs - run.startedAtMs),
+    timeoutMs: run.timeoutMs,
+    command: {
+      executable: run.cmd[0],
+      args: run.cmd.slice(1),
+      cwd: run.cwd,
+    },
+    stdoutTail: run.stdoutTail,
+    stderrTail: run.stderrTail,
+    exitCode: run.exitCode,
+    signal: run.signal,
+    error: run.error,
+    resultsFile,
+    stats: report?.stats ?? null,
+  };
+}
+
+function idleStatus(cwd: string) {
+  return {
+    runId: null,
+    state: 'idle' as const,
+    tracking: false,
+    pid: null,
+    startedAt: null,
+    completedAt: null,
+    elapsedMs: 0,
+    timeoutMs: null,
+    command: null,
+    stdoutTail: '',
+    stderrTail: '',
+    exitCode: null,
+    signal: null,
+    error: null,
+    resultsFile: resultsFileStatus(cwd),
+    stats: readLastReport(cwd)?.stats ?? null,
+  };
+}
+
+function latestRunForDir(cwd: string): TrackedRun | null {
+  let latest: TrackedRun | null = null;
+  for (const run of runs.values()) {
+    if (run.cwd !== cwd) continue;
+    if (!latest || run.startedAtMs > latest.startedAtMs) latest = run;
+  }
+  return latest;
 }
 
 function buildListTestsCmd(tag?: string): string[] {
@@ -326,6 +542,12 @@ server.registerTool(
         .positive()
         .optional()
         .describe('Timeout in milliseconds for the whole test run. Defaults to 300000.'),
+      wait: z
+        .boolean()
+        .optional()
+        .describe(
+          'Wait for completion before returning. Defaults to true. Set false to start a background run and poll it with get_run_status.'
+        ),
       updateSnapshots: z
         .enum(['all', 'changed', 'missing', 'none'])
         .optional()
@@ -376,6 +598,7 @@ server.registerTool(
     browser,
     tag,
     timeout,
+    wait,
     updateSnapshots,
     headed,
     workers,
@@ -402,6 +625,11 @@ server.registerTool(
     if (trace) cmd.push('--trace', trace);
 
     const effectiveTimeout = timeout ?? 300_000;
+    if (wait === false) {
+      const run = startTrackedRun(cmd, wd.dir, effectiveTimeout);
+      return ok(runStatus(run));
+    }
+
     const result = runPlaywright(cmd, wd.dir, effectiveTimeout);
 
     if (result.error) {
@@ -420,24 +648,35 @@ server.registerTool(
         `Test run completed but results.json was not found.\nstderr: ${result.stderr ?? ''}`
       );
 
-    const specs = collectSpecs(report.suites);
-    const summary = specs.map(({ spec: s, file }) => ({
-      title: s.title,
-      file,
-      ok: s.ok,
-      // results.at(-1) = final retry attempt — authoritative outcome when Playwright retries are configured
-      results: s.tests.map((t) => {
-        const last = t.results.at(-1);
-        return {
-          project: t.projectName,
-          status: last?.status ?? 'unknown',
-          duration: last?.duration ?? 0,
-          error: last?.error?.message ?? null,
-        };
-      }),
-    }));
+    return ok(summarizeReport(report, result.status ?? -1));
+  }
+);
 
-    return ok({ exitCode: result.status ?? -1, stats: report.stats, tests: summary });
+server.registerTool(
+  'get_run_status',
+  {
+    description:
+      'Return status for a Playwright run. Pass runId for a specific background run, or omit it to inspect the latest tracked run for a workingDirectory.',
+    inputSchema: {
+      workingDirectory: workingDirectoryField,
+      runId: z
+        .string()
+        .optional()
+        .describe('Run identifier returned by run_tests with wait=false.'),
+    },
+  },
+  async ({ workingDirectory, runId }) => {
+    if (runId) {
+      const run = runs.get(runId);
+      if (!run) return err(`Unknown runId: ${runId}`);
+      return ok(runStatus(run));
+    }
+
+    const wd = resolveWorkingDir(workingDirectory);
+    if ('error' in wd) return err(wd.error);
+
+    const run = latestRunForDir(wd.dir);
+    return ok(run ? runStatus(run) : idleStatus(wd.dir));
   }
 );
 

--- a/test/server.test.ts
+++ b/test/server.test.ts
@@ -1,9 +1,11 @@
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
+import { EventEmitter } from 'events';
 import { mkdirSync, mkdtempSync, rmSync, symlinkSync, unlinkSync, writeFileSync } from 'fs';
 import { tmpdir } from 'os';
 import { join } from 'path';
+import { PassThrough } from 'stream';
 import { fileURLToPath } from 'url';
 import pkg from '../package.json' with { type: 'json' };
 import { stats, suites } from './fixtures/data.js';
@@ -12,11 +14,12 @@ vi.mock('child_process', async (importOriginal) => {
   const actual = await importOriginal<typeof import('child_process')>();
   return {
     ...actual,
+    spawn: vi.fn(),
     spawnSync: vi.fn(() => ({ status: 0, stdout: '', stderr: '' })),
   };
 });
 
-import { spawnSync } from 'child_process';
+import { spawn, spawnSync } from 'child_process';
 import {
   ALLOWED_DIRS,
   buildListTestsCmd,
@@ -29,6 +32,56 @@ import {
 } from '../index.js';
 
 const spawnSyncMock = spawnSync as unknown as ReturnType<typeof vi.fn>;
+const spawnMock = spawn as unknown as ReturnType<typeof vi.fn>;
+
+type SpawnControl = {
+  child: EventEmitter & {
+    pid?: number;
+    stdout: PassThrough;
+    stderr: PassThrough;
+    kill: ReturnType<typeof vi.fn>;
+  };
+  fail: (error: Error) => void;
+  finish: (result?: {
+    code?: number | null;
+    signal?: NodeJS.Signals | null;
+    stdout?: string;
+    stderr?: string;
+  }) => void;
+};
+
+function createSpawnControl(pid = 4321): SpawnControl {
+  const child = new EventEmitter() as SpawnControl['child'];
+  child.pid = pid;
+  child.stdout = new PassThrough();
+  child.stderr = new PassThrough();
+
+  let closed = false;
+  const finish: SpawnControl['finish'] = (result = {}) => {
+    if (closed) return;
+    closed = true;
+    if (result.stdout) child.stdout.write(result.stdout);
+    if (result.stderr) child.stderr.write(result.stderr);
+    child.stdout.end();
+    child.stderr.end();
+    child.emit('close', result.code ?? 0, result.signal ?? null);
+  };
+
+  child.kill = vi.fn((signal: NodeJS.Signals = 'SIGTERM') => {
+    finish({ code: null, signal });
+    return true;
+  });
+
+  return {
+    child,
+    fail: (error: Error) => child.emit('error', error),
+    finish,
+  };
+}
+
+function waitForRunEvents() {
+  return new Promise((resolve) => setTimeout(resolve, 0));
+}
 
 const resultsDir = fileURLToPath(new URL('./fixtures/test-results', import.meta.url));
 const resultsFile = join(resultsDir, 'results.json');
@@ -211,6 +264,186 @@ describe('run_tests — timeout', () => {
     expect(result.isError).toBe(true);
     const text = (result.content as TextContent[])[0].text;
     expect(text).toContain('exceeded the 300000ms timeout');
+  });
+});
+
+describe('run_tests — non-blocking status polling', () => {
+  beforeEach(() => {
+    spawnMock.mockReset();
+  });
+
+  afterEach(() => {
+    writeDefaultReport();
+  });
+
+  it('starts a run without waiting and returns a stable runId', async () => {
+    const run = createSpawnControl();
+    spawnMock.mockReturnValueOnce(run.child);
+
+    const data = parseResult(
+      await client.callTool({ name: 'run_tests', arguments: { wait: false } })
+    );
+
+    expect(data.runId).toMatch(/^run-/);
+    expect(data.state).toBe('running');
+    expect(data.pid).toBe(4321);
+    expect(spawnMock).toHaveBeenCalledTimes(1);
+    expect(run.child.kill).not.toHaveBeenCalled();
+  });
+
+  it('reports the status of an active run with command metadata and results.json state', async () => {
+    writeDefaultReport();
+    await new Promise((resolve) => setTimeout(resolve, 5));
+    const run = createSpawnControl(9876);
+    spawnMock.mockReturnValueOnce(run.child);
+    const started = parseResult(
+      await client.callTool({ name: 'run_tests', arguments: { wait: false, tag: '@smoke' } })
+    );
+
+    const status = parseResult(
+      await client.callTool({ name: 'get_run_status', arguments: { runId: started.runId } })
+    );
+
+    expect(status).toMatchObject({
+      runId: started.runId,
+      state: 'running',
+      pid: 9876,
+      exitCode: null,
+      signal: null,
+      error: null,
+    });
+    expect(status.command.args).toContain('--grep');
+    expect(status.command.args).toContain('@smoke');
+    expect(status.resultsFile.exists).toBe(true);
+    expect(status.resultsFile.updatedAfterStart).toBe(false);
+    expect(status.resultsFile.mtimeMs).toEqual(expect.any(Number));
+    expect(status.stats).toBeNull();
+    expect(status.elapsedMs).toEqual(expect.any(Number));
+  });
+
+  it('uses the latest tracked run for the working directory when runId is omitted', async () => {
+    const run = createSpawnControl(2468);
+    spawnMock.mockReturnValueOnce(run.child);
+    const started = parseResult(
+      await client.callTool({ name: 'run_tests', arguments: { wait: false } })
+    );
+
+    const status = parseResult(await client.callTool({ name: 'get_run_status', arguments: {} }));
+
+    expect(status.runId).toBe(started.runId);
+    expect(status.state).toBe('running');
+    expect(status.pid).toBe(2468);
+  });
+
+  it('returns idle status when runId is omitted and no run is tracked for the working directory', async () => {
+    const status = parseResult(
+      await client.callTool({
+        name: 'get_run_status',
+        arguments: { workingDirectory: 'test/fixtures/pw-project' },
+      })
+    );
+
+    expect(status).toMatchObject({
+      runId: null,
+      state: 'idle',
+      tracking: false,
+      pid: null,
+      command: null,
+      exitCode: null,
+      signal: null,
+      error: null,
+    });
+    expect(status.resultsFile.exists).toEqual(expect.any(Boolean));
+  });
+
+  it('reports terminal failed status with stderr tail and parsed stats', async () => {
+    const run = createSpawnControl();
+    spawnMock.mockReturnValueOnce(run.child);
+    const started = parseResult(
+      await client.callTool({ name: 'run_tests', arguments: { wait: false } })
+    );
+
+    writeDefaultReport();
+    run.finish({ code: 1, stderr: 'one test failed' });
+    await waitForRunEvents();
+
+    const status = parseResult(
+      await client.callTool({ name: 'get_run_status', arguments: { runId: started.runId } })
+    );
+    expect(status).toMatchObject({
+      runId: started.runId,
+      state: 'failed',
+      exitCode: 1,
+      signal: null,
+      stderrTail: 'one test failed',
+      stats,
+    });
+    expect(status.completedAt).toEqual(expect.any(String));
+  });
+
+  it('reports timeout status after killing a long-running process', async () => {
+    const run = createSpawnControl();
+    spawnMock.mockReturnValueOnce(run.child);
+    const started = parseResult(
+      await client.callTool({ name: 'run_tests', arguments: { wait: false, timeout: 1 } })
+    );
+
+    await new Promise((resolve) => setTimeout(resolve, 5));
+
+    const status = parseResult(
+      await client.callTool({ name: 'get_run_status', arguments: { runId: started.runId } })
+    );
+    expect(status.state).toBe('timedOut');
+    expect(status.signal).toBe('SIGTERM');
+    expect(status.error).toContain('exceeded the 1ms timeout');
+    expect(run.child.kill).toHaveBeenCalledWith('SIGTERM');
+  });
+
+  it('reports spawn failure status', async () => {
+    const run = createSpawnControl();
+    spawnMock.mockReturnValueOnce(run.child);
+    const started = parseResult(
+      await client.callTool({ name: 'run_tests', arguments: { wait: false } })
+    );
+
+    run.fail(new Error('ENOENT'));
+    await waitForRunEvents();
+
+    const status = parseResult(
+      await client.callTool({ name: 'get_run_status', arguments: { runId: started.runId } })
+    );
+    expect(status.state).toBe('failed');
+    expect(status.error).toContain('Failed to spawn Playwright');
+    expect(status.error).toContain('ENOENT');
+  });
+
+  it('reports a completed run with missing results.json without reading stale data', async () => {
+    deleteReport();
+    const run = createSpawnControl();
+    spawnMock.mockReturnValueOnce(run.child);
+    const started = parseResult(
+      await client.callTool({ name: 'run_tests', arguments: { wait: false } })
+    );
+
+    run.finish({ code: 0 });
+    await waitForRunEvents();
+
+    const status = parseResult(
+      await client.callTool({ name: 'get_run_status', arguments: { runId: started.runId } })
+    );
+    expect(status.state).toBe('completed');
+    expect(status.resultsFile.exists).toBe(false);
+    expect(status.resultsFile.mtimeMs).toBeNull();
+    expect(status.stats).toBeNull();
+  });
+
+  it('returns a structured error for an unknown runId', async () => {
+    const result = await client.callTool({
+      name: 'get_run_status',
+      arguments: { runId: 'run-does-not-exist' },
+    });
+    expect(result.isError).toBe(true);
+    expect((result.content as TextContent[])[0].text).toContain('Unknown runId');
   });
 });
 

--- a/test/server.test.ts
+++ b/test/server.test.ts
@@ -15,11 +15,19 @@ vi.mock('child_process', async (importOriginal) => {
   return {
     ...actual,
     spawn: vi.fn(),
-    spawnSync: vi.fn(() => ({ status: 0, stdout: '', stderr: '' })),
+    spawnSync: vi.fn(() => ({
+      pid: 1234,
+      output: [null, '', ''],
+      stdout: '',
+      stderr: '',
+      status: 0,
+      signal: null,
+    })),
   };
 });
 
 import { spawn, spawnSync } from 'child_process';
+import type { SpawnSyncReturns } from 'child_process';
 import {
   ALLOWED_DIRS,
   buildListTestsCmd,
@@ -31,16 +39,37 @@ import {
   server,
 } from '../index.js';
 
-const spawnSyncMock = spawnSync as unknown as ReturnType<typeof vi.fn>;
-const spawnMock = spawn as unknown as ReturnType<typeof vi.fn>;
+const KILL_ESCALATION_MS_UNDER_TEST = 5_000;
+const ACTIVE_RUN_LIMIT_UNDER_TEST = 4;
+const TRACKED_RUN_LIMIT_UNDER_TEST = 50;
+const spawnSyncMock = vi.mocked(spawnSync);
+const spawnMock = vi.mocked(spawn);
 
-type SpawnControl = {
-  child: EventEmitter & {
-    pid?: number;
+function spawnSyncResult(
+  overrides: Partial<SpawnSyncReturns<string>> = {}
+): SpawnSyncReturns<string> {
+  const stdout = overrides.stdout ?? '';
+  const stderr = overrides.stderr ?? '';
+  return {
+    pid: overrides.pid ?? 1234,
+    output: overrides.output ?? [null, stdout, stderr],
+    stdout,
+    stderr,
+    status: overrides.status === undefined ? 0 : overrides.status,
+    signal: overrides.signal === undefined ? null : overrides.signal,
+    ...(overrides.error ? { error: overrides.error } : {}),
+  };
+}
+
+type SpawnChildMock = ReturnType<typeof spawn> &
+  EventEmitter & {
     stdout: PassThrough;
     stderr: PassThrough;
     kill: ReturnType<typeof vi.fn>;
   };
+
+type SpawnControl = {
+  child: SpawnChildMock;
   fail: (error: Error) => void;
   finish: (result?: {
     code?: number | null;
@@ -50,9 +79,13 @@ type SpawnControl = {
   }) => void;
 };
 
-function createSpawnControl(pid = 4321): SpawnControl {
-  const child = new EventEmitter() as SpawnControl['child'];
-  child.pid = pid;
+function createSpawnControl(
+  options: number | { pid?: number; closeOnKill?: boolean } = 4321
+): SpawnControl {
+  const pid = typeof options === 'number' ? options : (options.pid ?? 4321);
+  const closeOnKill = typeof options === 'number' ? true : (options.closeOnKill ?? true);
+  const child = new EventEmitter() as SpawnChildMock;
+  Object.defineProperty(child, 'pid', { value: pid, configurable: true });
   child.stdout = new PassThrough();
   child.stderr = new PassThrough();
 
@@ -68,7 +101,7 @@ function createSpawnControl(pid = 4321): SpawnControl {
   };
 
   child.kill = vi.fn((signal: NodeJS.Signals = 'SIGTERM') => {
-    finish({ code: null, signal });
+    if (closeOnKill) finish({ code: null, signal });
     return true;
   });
 
@@ -77,6 +110,27 @@ function createSpawnControl(pid = 4321): SpawnControl {
     fail: (error: Error) => child.emit('error', error),
     finish,
   };
+}
+
+let spawnControls: SpawnControl[] = [];
+let processKillSpy: ReturnType<typeof vi.spyOn> | null = null;
+
+function mockProcessGroupSignalSuccess() {
+  processKillSpy = vi.spyOn(process, 'kill').mockImplementation(() => true);
+  return processKillSpy;
+}
+
+function mockProcessGroupSignalFailure() {
+  processKillSpy = vi.spyOn(process, 'kill').mockImplementation(() => {
+    throw new Error('no such process group');
+  });
+  return processKillSpy;
+}
+
+function mockNextSpawn(control: SpawnControl): SpawnControl {
+  spawnControls.push(control);
+  spawnMock.mockReturnValueOnce(control.child);
+  return control;
 }
 
 function waitForRunEvents() {
@@ -234,13 +288,15 @@ describe('run_tests — timeout', () => {
     // Node's spawnSync({ timeout }) populates BOTH error.code='ETIMEDOUT' and signal='SIGTERM'
     // when the timer fires; the error branch runs first, so assert on that path.
     const timeoutError = Object.assign(new Error('spawnSync npx ETIMEDOUT'), { code: 'ETIMEDOUT' });
-    spawnSyncMock.mockReturnValueOnce({
-      status: null,
-      signal: 'SIGTERM',
-      error: timeoutError,
-      stdout: '',
-      stderr: '',
-    });
+    spawnSyncMock.mockReturnValueOnce(
+      spawnSyncResult({
+        status: null,
+        signal: 'SIGTERM',
+        error: timeoutError,
+        stdout: '',
+        stderr: '',
+      })
+    );
     const result = await client.callTool({
       name: 'run_tests',
       arguments: { timeout: 1000 },
@@ -253,13 +309,15 @@ describe('run_tests — timeout', () => {
 
   it('reports the default 300000 ms in the timeout message when no timeout was specified', async () => {
     const timeoutError = Object.assign(new Error('spawnSync npx ETIMEDOUT'), { code: 'ETIMEDOUT' });
-    spawnSyncMock.mockReturnValueOnce({
-      status: null,
-      signal: 'SIGTERM',
-      error: timeoutError,
-      stdout: '',
-      stderr: '',
-    });
+    spawnSyncMock.mockReturnValueOnce(
+      spawnSyncResult({
+        status: null,
+        signal: 'SIGTERM',
+        error: timeoutError,
+        stdout: '',
+        stderr: '',
+      })
+    );
     const result = await client.callTool({ name: 'run_tests', arguments: {} });
     expect(result.isError).toBe(true);
     const text = (result.content as TextContent[])[0].text;
@@ -270,15 +328,21 @@ describe('run_tests — timeout', () => {
 describe('run_tests — non-blocking status polling', () => {
   beforeEach(() => {
     spawnMock.mockReset();
+    spawnControls = [];
+    processKillSpy = null;
   });
 
   afterEach(() => {
+    for (const control of spawnControls) control.finish({ code: 0 });
+    spawnControls = [];
+    processKillSpy?.mockRestore();
+    processKillSpy = null;
+    vi.useRealTimers();
     writeDefaultReport();
   });
 
   it('starts a run without waiting and returns a stable runId', async () => {
-    const run = createSpawnControl();
-    spawnMock.mockReturnValueOnce(run.child);
+    const run = mockNextSpawn(createSpawnControl());
 
     const data = parseResult(
       await client.callTool({ name: 'run_tests', arguments: { wait: false } })
@@ -294,8 +358,7 @@ describe('run_tests — non-blocking status polling', () => {
   it('reports the status of an active run with command metadata and results.json state', async () => {
     writeDefaultReport();
     await new Promise((resolve) => setTimeout(resolve, 5));
-    const run = createSpawnControl(9876);
-    spawnMock.mockReturnValueOnce(run.child);
+    mockNextSpawn(createSpawnControl(9876));
     const started = parseResult(
       await client.callTool({ name: 'run_tests', arguments: { wait: false, tag: '@smoke' } })
     );
@@ -321,9 +384,27 @@ describe('run_tests — non-blocking status polling', () => {
     expect(status.elapsedMs).toEqual(expect.any(Number));
   });
 
+  it('reports live stats for a running run after results.json is updated', async () => {
+    const liveStats = { expected: 3, unexpected: 1, skipped: 0, duration: 321 };
+    mockNextSpawn(createSpawnControl(1357));
+    const started = parseResult(
+      await client.callTool({ name: 'run_tests', arguments: { wait: false } })
+    );
+
+    await new Promise((resolve) => setTimeout(resolve, 5));
+    writeCustomReport({ suites, stats: liveStats });
+
+    const status = parseResult(
+      await client.callTool({ name: 'get_run_status', arguments: { runId: started.runId } })
+    );
+
+    expect(status.state).toBe('running');
+    expect(status.resultsFile.updatedAfterStart).toBe(true);
+    expect(status.stats).toEqual(liveStats);
+  });
+
   it('uses the latest tracked run for the working directory when runId is omitted', async () => {
-    const run = createSpawnControl(2468);
-    spawnMock.mockReturnValueOnce(run.child);
+    mockNextSpawn(createSpawnControl(2468));
     const started = parseResult(
       await client.callTool({ name: 'run_tests', arguments: { wait: false } })
     );
@@ -333,6 +414,30 @@ describe('run_tests — non-blocking status polling', () => {
     expect(status.runId).toBe(started.runId);
     expect(status.state).toBe('running');
     expect(status.pid).toBe(2468);
+  });
+
+  it('uses insertion order to select the latest run when two runs start in the same millisecond', async () => {
+    const dateSpy = vi.spyOn(Date, 'now').mockReturnValue(1_800_000_000_000);
+    try {
+      const first = mockNextSpawn(createSpawnControl(1111));
+      const firstStarted = parseResult(
+        await client.callTool({ name: 'run_tests', arguments: { wait: false } })
+      );
+      first.finish({ code: 0 });
+
+      mockNextSpawn(createSpawnControl(2222));
+      const secondStarted = parseResult(
+        await client.callTool({ name: 'run_tests', arguments: { wait: false } })
+      );
+
+      const status = parseResult(await client.callTool({ name: 'get_run_status', arguments: {} }));
+
+      expect(firstStarted.runId).not.toBe(secondStarted.runId);
+      expect(status.runId).toBe(secondStarted.runId);
+      expect(status.pid).toBe(2222);
+    } finally {
+      dateSpy.mockRestore();
+    }
   });
 
   it('returns idle status when runId is omitted and no run is tracked for the working directory', async () => {
@@ -357,8 +462,7 @@ describe('run_tests — non-blocking status polling', () => {
   });
 
   it('reports terminal failed status with stderr tail and parsed stats', async () => {
-    const run = createSpawnControl();
-    spawnMock.mockReturnValueOnce(run.child);
+    const run = mockNextSpawn(createSpawnControl());
     const started = parseResult(
       await client.callTool({ name: 'run_tests', arguments: { wait: false } })
     );
@@ -381,9 +485,38 @@ describe('run_tests — non-blocking status polling', () => {
     expect(status.completedAt).toEqual(expect.any(String));
   });
 
+  it('keeps report stats isolated to the run that produced them', async () => {
+    const firstStats = { expected: 11, unexpected: 0, skipped: 0, duration: 110 };
+    const secondStats = { expected: 22, unexpected: 1, skipped: 0, duration: 220 };
+
+    const first = mockNextSpawn(createSpawnControl(1111));
+    const firstStarted = parseResult(
+      await client.callTool({ name: 'run_tests', arguments: { wait: false } })
+    );
+    writeCustomReport({ suites, stats: firstStats });
+    first.finish({ code: 0 });
+
+    const second = mockNextSpawn(createSpawnControl(2222));
+    const secondStarted = parseResult(
+      await client.callTool({ name: 'run_tests', arguments: { wait: false } })
+    );
+    writeCustomReport({ suites, stats: secondStats });
+    second.finish({ code: 0 });
+
+    const firstStatus = parseResult(
+      await client.callTool({ name: 'get_run_status', arguments: { runId: firstStarted.runId } })
+    );
+    const secondStatus = parseResult(
+      await client.callTool({ name: 'get_run_status', arguments: { runId: secondStarted.runId } })
+    );
+
+    expect(firstStatus.stats).toEqual(firstStats);
+    expect(secondStatus.stats).toEqual(secondStats);
+  });
+
   it('reports timeout status after killing a long-running process', async () => {
-    const run = createSpawnControl();
-    spawnMock.mockReturnValueOnce(run.child);
+    mockProcessGroupSignalFailure();
+    const run = mockNextSpawn(createSpawnControl());
     const started = parseResult(
       await client.callTool({ name: 'run_tests', arguments: { wait: false, timeout: 1 } })
     );
@@ -399,9 +532,95 @@ describe('run_tests — non-blocking status polling', () => {
     expect(run.child.kill).toHaveBeenCalledWith('SIGTERM');
   });
 
+  it('escalates a timed-out run to SIGKILL when SIGTERM does not close the process', async () => {
+    vi.useFakeTimers();
+    const killSpy = mockProcessGroupSignalFailure();
+    const run = mockNextSpawn(createSpawnControl({ closeOnKill: false }));
+    const started = parseResult(
+      await client.callTool({ name: 'run_tests', arguments: { wait: false, timeout: 1 } })
+    );
+
+    await vi.advanceTimersByTimeAsync(1);
+    expect(run.child.kill).toHaveBeenCalledWith('SIGTERM');
+
+    await vi.advanceTimersByTimeAsync(KILL_ESCALATION_MS_UNDER_TEST);
+
+    const status = parseResult(
+      await client.callTool({ name: 'get_run_status', arguments: { runId: started.runId } })
+    );
+    expect(run.child.kill).toHaveBeenCalledWith('SIGKILL');
+    if (process.platform !== 'win32') {
+      expect(killSpy).toHaveBeenCalledWith(-4321, 'SIGTERM');
+      expect(killSpy).toHaveBeenCalledWith(-4321, 'SIGKILL');
+    }
+    expect(status.state).toBe('running');
+    expect(status.signal).toBe('SIGKILL');
+    expect(status.completedAt).toBeNull();
+    expect(status.error).toContain('exceeded the 1ms timeout');
+
+    run.finish({ code: null, signal: 'SIGKILL' });
+    const closedStatus = parseResult(
+      await client.callTool({ name: 'get_run_status', arguments: { runId: started.runId } })
+    );
+    expect(closedStatus.state).toBe('timedOut');
+    expect(closedStatus.completedAt).toEqual(expect.any(String));
+  });
+
+  it('preserves timeout status when the child emits an error after timeout', async () => {
+    vi.useFakeTimers();
+    mockProcessGroupSignalFailure();
+    const run = mockNextSpawn(createSpawnControl({ closeOnKill: false }));
+    const started = parseResult(
+      await client.callTool({ name: 'run_tests', arguments: { wait: false, timeout: 1 } })
+    );
+
+    await vi.advanceTimersByTimeAsync(1);
+    run.fail(new Error('post-timeout process error'));
+
+    const status = parseResult(
+      await client.callTool({ name: 'get_run_status', arguments: { runId: started.runId } })
+    );
+    expect(status.state).toBe('timedOut');
+    expect(status.error).toContain('exceeded the 1ms timeout');
+    expect(status.error).not.toContain('post-timeout process error');
+    expect(status.completedAt).toEqual(expect.any(String));
+  });
+
+  it('signals the process group instead of the direct child when the group signal succeeds', async () => {
+    vi.useFakeTimers();
+    const killSpy = mockProcessGroupSignalSuccess();
+    const run = mockNextSpawn(createSpawnControl({ closeOnKill: false }));
+    const started = parseResult(
+      await client.callTool({ name: 'run_tests', arguments: { wait: false, timeout: 1 } })
+    );
+    expect(spawnMock.mock.calls[0][2]).toMatchObject({
+      detached: process.platform !== 'win32',
+    });
+
+    await vi.advanceTimersByTimeAsync(1);
+
+    if (process.platform === 'win32') {
+      expect(run.child.kill).toHaveBeenCalledWith('SIGTERM');
+    } else {
+      expect(killSpy).toHaveBeenCalledWith(-4321, 'SIGTERM');
+      expect(run.child.kill).not.toHaveBeenCalled();
+    }
+
+    run.finish({ code: null, signal: 'SIGTERM' });
+    const status = parseResult(
+      await client.callTool({ name: 'get_run_status', arguments: { runId: started.runId } })
+    );
+    expect(status.state).toBe('timedOut');
+    expect(status.signal).toBe('SIGTERM');
+
+    await vi.advanceTimersByTimeAsync(KILL_ESCALATION_MS_UNDER_TEST);
+    if (process.platform !== 'win32') {
+      expect(killSpy).toHaveBeenCalledWith(-4321, 'SIGKILL');
+    }
+  });
+
   it('reports spawn failure status', async () => {
-    const run = createSpawnControl();
-    spawnMock.mockReturnValueOnce(run.child);
+    const run = mockNextSpawn(createSpawnControl());
     const started = parseResult(
       await client.callTool({ name: 'run_tests', arguments: { wait: false } })
     );
@@ -417,10 +636,25 @@ describe('run_tests — non-blocking status polling', () => {
     expect(status.error).toContain('ENOENT');
   });
 
+  it('reports synchronous spawn exceptions as failed tracked runs', async () => {
+    spawnMock.mockImplementationOnce(() => {
+      throw new Error('spawn threw');
+    });
+
+    const started = parseResult(
+      await client.callTool({ name: 'run_tests', arguments: { wait: false } })
+    );
+    const status = parseResult(
+      await client.callTool({ name: 'get_run_status', arguments: { runId: started.runId } })
+    );
+
+    expect(status.state).toBe('failed');
+    expect(status.error).toContain('spawn threw');
+  });
+
   it('reports a completed run with missing results.json without reading stale data', async () => {
     deleteReport();
-    const run = createSpawnControl();
-    spawnMock.mockReturnValueOnce(run.child);
+    const run = mockNextSpawn(createSpawnControl());
     const started = parseResult(
       await client.callTool({ name: 'run_tests', arguments: { wait: false } })
     );
@@ -444,6 +678,144 @@ describe('run_tests — non-blocking status polling', () => {
     });
     expect(result.isError).toBe(true);
     expect((result.content as TextContent[])[0].text).toContain('Unknown runId');
+  });
+
+  it('rejects starting a second tracked run in the same working directory while one is active', async () => {
+    mockNextSpawn(createSpawnControl(1111));
+    const started = parseResult(
+      await client.callTool({ name: 'run_tests', arguments: { wait: false } })
+    );
+
+    const result = await client.callTool({ name: 'run_tests', arguments: { wait: false } });
+
+    expect(result.isError).toBe(true);
+    expect((result.content as TextContent[])[0].text).toContain('already running');
+    expect((result.content as TextContent[])[0].text).toContain(started.runId);
+    expect(spawnMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps a timed-out process active until timeout cleanup completes', async () => {
+    vi.useFakeTimers();
+    mockProcessGroupSignalFailure();
+    mockNextSpawn(createSpawnControl({ closeOnKill: false }));
+    const started = parseResult(
+      await client.callTool({ name: 'run_tests', arguments: { wait: false, timeout: 1 } })
+    );
+    await vi.advanceTimersByTimeAsync(1);
+
+    const result = await client.callTool({ name: 'run_tests', arguments: { wait: false } });
+
+    expect(result.isError).toBe(true);
+    expect((result.content as TextContent[])[0].text).toContain('already running');
+    expect((result.content as TextContent[])[0].text).toContain(started.runId);
+    expect(spawnMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('rejects new tracked runs when the global active run limit is reached', async () => {
+    const workingDirectories = [
+      '.',
+      'test',
+      'test/fixtures',
+      'test/fixtures/test-results',
+      'test/fixtures/pw-project',
+    ];
+
+    for (let i = 0; i < ACTIVE_RUN_LIMIT_UNDER_TEST; i++) {
+      mockNextSpawn(createSpawnControl(6_000 + i));
+      parseResult(
+        await client.callTool({
+          name: 'run_tests',
+          arguments: { wait: false, workingDirectory: workingDirectories[i] },
+        })
+      );
+    }
+
+    const result = await client.callTool({
+      name: 'run_tests',
+      arguments: {
+        wait: false,
+        workingDirectory: workingDirectories[ACTIVE_RUN_LIMIT_UNDER_TEST],
+      },
+    });
+
+    expect(result.isError).toBe(true);
+    expect((result.content as TextContent[])[0].text).toContain('Too many active Playwright runs');
+    expect(spawnMock).toHaveBeenCalledTimes(ACTIVE_RUN_LIMIT_UNDER_TEST);
+  });
+
+  it('requires a supplied workingDirectory to match the requested runId', async () => {
+    mockNextSpawn(createSpawnControl());
+    const started = parseResult(
+      await client.callTool({ name: 'run_tests', arguments: { wait: false } })
+    );
+
+    const result = await client.callTool({
+      name: 'get_run_status',
+      arguments: { runId: started.runId, workingDirectory: 'test/fixtures/pw-project' },
+    });
+
+    expect(result.isError).toBe(true);
+    expect((result.content as TextContent[])[0].text).toContain('does not match');
+  });
+
+  it('validates supplied workingDirectory before matching it to a runId', async () => {
+    mockNextSpawn(createSpawnControl());
+    const started = parseResult(
+      await client.callTool({ name: 'run_tests', arguments: { wait: false } })
+    );
+
+    const result = await client.callTool({
+      name: 'get_run_status',
+      arguments: { runId: started.runId, workingDirectory: 'test/fixtures/does-not-exist' },
+    });
+
+    expect(result.isError).toBe(true);
+    expect((result.content as TextContent[])[0].text).toContain('does not exist');
+  });
+
+  it('accepts runId with a matching supplied workingDirectory', async () => {
+    mockNextSpawn(createSpawnControl(7777));
+    const started = parseResult(
+      await client.callTool({ name: 'run_tests', arguments: { wait: false } })
+    );
+
+    const status = parseResult(
+      await client.callTool({
+        name: 'get_run_status',
+        arguments: { runId: started.runId, workingDirectory: '.' },
+      })
+    );
+
+    expect(status.runId).toBe(started.runId);
+    expect(status.pid).toBe(7777);
+  });
+
+  it('evicts old terminal runs after the tracked run limit', async () => {
+    let firstRunId = '';
+    let lastRunId = '';
+    for (let i = 0; i < TRACKED_RUN_LIMIT_UNDER_TEST + 1; i++) {
+      const run = mockNextSpawn(createSpawnControl(5_000 + i));
+      const started = parseResult(
+        await client.callTool({ name: 'run_tests', arguments: { wait: false } })
+      );
+      if (i === 0) firstRunId = started.runId;
+      lastRunId = started.runId;
+      run.finish({ code: 0 });
+    }
+
+    const result = await client.callTool({
+      name: 'get_run_status',
+      arguments: { runId: firstRunId },
+    });
+
+    expect(result.isError).toBe(true);
+    expect((result.content as TextContent[])[0].text).toContain('Unknown runId');
+
+    const retained = parseResult(
+      await client.callTool({ name: 'get_run_status', arguments: { runId: lastRunId } })
+    );
+    expect(retained.runId).toBe(lastRunId);
+    expect(retained.state).toBe('completed');
   });
 });
 
@@ -659,11 +1031,7 @@ describe('run_tests — spawn failure', () => {
   beforeEach(() => spawnSyncMock.mockClear());
 
   it('returns error when Playwright cannot be spawned', async () => {
-    spawnSyncMock.mockReturnValueOnce({
-      error: new Error('ENOENT'),
-      stdout: '',
-      stderr: '',
-    });
+    spawnSyncMock.mockReturnValueOnce(spawnSyncResult({ error: new Error('ENOENT') }));
     const result = await client.callTool({ name: 'run_tests', arguments: {} });
     expect(result.isError).toBe(true);
     const text = (result.content as TextContent[])[0].text;
@@ -677,11 +1045,9 @@ describe('run_tests — missing results.json', () => {
   afterEach(() => writeDefaultReport());
 
   it('returns error referencing stderr when the report file is absent', async () => {
-    spawnSyncMock.mockReturnValueOnce({
-      status: 1,
-      stdout: '',
-      stderr: 'reporter failed to write output',
-    });
+    spawnSyncMock.mockReturnValueOnce(
+      spawnSyncResult({ status: 1, stderr: 'reporter failed to write output' })
+    );
     const result = await client.callTool({ name: 'run_tests', arguments: {} });
     expect(result.isError).toBe(true);
     const text = (result.content as TextContent[])[0].text;
@@ -1036,8 +1402,8 @@ describe('run_tests — command construction', () => {
 describe('run_tests — edge cases in spawn result', () => {
   afterEach(() => writeDefaultReport());
 
-  it('reports exitCode -1 when spawn result has no status field', async () => {
-    spawnSyncMock.mockReturnValueOnce({ stdout: '', stderr: '' });
+  it('reports exitCode -1 when spawn result has null status', async () => {
+    spawnSyncMock.mockReturnValueOnce(spawnSyncResult({ status: null }));
     const data = parseResult(await client.callTool({ name: 'run_tests', arguments: {} }));
     expect(data.exitCode).toBe(-1);
   });
@@ -1072,7 +1438,7 @@ describe('run_tests — edge cases in spawn result', () => {
 
   it('handles spawn result with no stderr field when the report is missing', async () => {
     deleteReport();
-    spawnSyncMock.mockReturnValueOnce({ status: 1 });
+    spawnSyncMock.mockReturnValueOnce(spawnSyncResult({ status: 1 }));
     const result = await client.callTool({ name: 'run_tests', arguments: {} });
     expect(result.isError).toBe(true);
     expect((result.content as TextContent[])[0].text).toMatch(/stderr:\s*$/);
@@ -1268,7 +1634,7 @@ describe('list_tests — via MCP client', () => {
         },
       ],
     });
-    spawnSyncMock.mockReturnValueOnce({ status: 0, stdout: reporterJson, stderr: '' });
+    spawnSyncMock.mockReturnValueOnce(spawnSyncResult({ stdout: reporterJson }));
 
     const data = parseResult(await client.callTool({ name: 'list_tests', arguments: {} }));
     expect(data.count).toBe(1);
@@ -1280,7 +1646,7 @@ describe('list_tests — via MCP client', () => {
   });
 
   it('passes --grep to Playwright when a tag filter is provided', async () => {
-    spawnSyncMock.mockReturnValueOnce({ status: 0, stdout: '{"suites":[]}', stderr: '' });
+    spawnSyncMock.mockReturnValueOnce(spawnSyncResult({ stdout: '{"suites":[]}' }));
     await client.callTool({ name: 'list_tests', arguments: { tag: '@smoke' } });
     const args = spawnSyncMock.mock.calls[0][1] as string[];
     expect(args).toContain('--grep');
@@ -1288,7 +1654,7 @@ describe('list_tests — via MCP client', () => {
   });
 
   it('returns error when Playwright cannot be spawned', async () => {
-    spawnSyncMock.mockReturnValueOnce({ error: new Error('ENOENT'), stdout: '', stderr: '' });
+    spawnSyncMock.mockReturnValueOnce(spawnSyncResult({ error: new Error('ENOENT') }));
     const result = await client.callTool({ name: 'list_tests', arguments: {} });
     expect(result.isError).toBe(true);
     expect((result.content as TextContent[])[0].text).toContain('Failed to spawn Playwright');
@@ -1296,13 +1662,15 @@ describe('list_tests — via MCP client', () => {
 
   it('surfaces an explicit error when spawnSync times out under the 30s list_tests cap', async () => {
     const timeoutError = Object.assign(new Error('spawnSync npx ETIMEDOUT'), { code: 'ETIMEDOUT' });
-    spawnSyncMock.mockReturnValueOnce({
-      status: null,
-      signal: 'SIGTERM',
-      error: timeoutError,
-      stdout: '',
-      stderr: '',
-    });
+    spawnSyncMock.mockReturnValueOnce(
+      spawnSyncResult({
+        status: null,
+        signal: 'SIGTERM',
+        error: timeoutError,
+        stdout: '',
+        stderr: '',
+      })
+    );
     const result = await client.callTool({ name: 'list_tests', arguments: {} });
     expect(result.isError).toBe(true);
     const text = (result.content as TextContent[])[0].text;
@@ -1311,11 +1679,13 @@ describe('list_tests — via MCP client', () => {
   });
 
   it('returns error when --list output cannot be parsed as JSON', async () => {
-    spawnSyncMock.mockReturnValueOnce({
-      status: 0,
-      stdout: 'no json here',
-      stderr: 'some warning',
-    });
+    spawnSyncMock.mockReturnValueOnce(
+      spawnSyncResult({
+        status: 0,
+        stdout: 'no json here',
+        stderr: 'some warning',
+      })
+    );
     const result = await client.callTool({ name: 'list_tests', arguments: {} });
     expect(result.isError).toBe(true);
     const text = (result.content as TextContent[])[0].text;
@@ -1323,8 +1693,8 @@ describe('list_tests — via MCP client', () => {
     expect(text).toContain('some warning');
   });
 
-  it('tolerates spawn result with missing stdout/stderr fields', async () => {
-    spawnSyncMock.mockReturnValueOnce({});
+  it('returns a parse error when --list stdout is empty', async () => {
+    spawnSyncMock.mockReturnValueOnce(spawnSyncResult());
     const result = await client.callTool({ name: 'list_tests', arguments: {} });
     expect(result.isError).toBe(true);
     const text = (result.content as TextContent[])[0].text;
@@ -1333,7 +1703,7 @@ describe('list_tests — via MCP client', () => {
   });
 
   it('returns zero tests when the reporter JSON has no suites field', async () => {
-    spawnSyncMock.mockReturnValueOnce({ status: 0, stdout: '{}', stderr: '' });
+    spawnSyncMock.mockReturnValueOnce(spawnSyncResult({ stdout: '{}' }));
     const data = parseResult(await client.callTool({ name: 'list_tests', arguments: {} }));
     expect(data).toEqual({ count: 0, tests: [] });
   });
@@ -1768,7 +2138,7 @@ describe('workingDirectory — positive acceptance on the other three tools (AC5
   // covered above; these are the positive counterparts.
 
   it('list_tests accepts a workingDirectory under the allowlist and uses it as spawn cwd', async () => {
-    spawnSyncMock.mockReturnValueOnce({ status: 0, stdout: '{"suites":[]}', stderr: '' });
+    spawnSyncMock.mockReturnValueOnce(spawnSyncResult({ stdout: '{"suites":[]}' }));
     const data = parseResult(
       await client.callTool({
         name: 'list_tests',

--- a/test/server.test.ts
+++ b/test/server.test.ts
@@ -2,7 +2,15 @@ import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } 
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
 import { EventEmitter } from 'events';
-import { mkdirSync, mkdtempSync, rmSync, symlinkSync, unlinkSync, writeFileSync } from 'fs';
+import {
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  symlinkSync,
+  unlinkSync,
+  utimesSync,
+  writeFileSync,
+} from 'fs';
 import { tmpdir } from 'os';
 import { join } from 'path';
 import { PassThrough } from 'stream';
@@ -146,6 +154,13 @@ function writeDefaultReport() {
 
 function writeCustomReport(report: unknown) {
   writeFileSync(resultsFile, JSON.stringify(report));
+}
+
+function markReportUpdatedAfter(startedAt: string) {
+  const startedAtMs = Date.parse(startedAt);
+  if (Number.isNaN(startedAtMs)) throw new Error(`Invalid startedAt timestamp: ${startedAt}`);
+  const updatedAt = new Date(startedAtMs + 1000);
+  utimesSync(resultsFile, updatedAt, updatedAt);
 }
 
 function deleteReport() {
@@ -468,6 +483,7 @@ describe('run_tests — non-blocking status polling', () => {
     );
 
     writeDefaultReport();
+    markReportUpdatedAfter(started.startedAt);
     run.finish({ code: 1, stderr: 'one test failed' });
     await waitForRunEvents();
 
@@ -494,6 +510,7 @@ describe('run_tests — non-blocking status polling', () => {
       await client.callTool({ name: 'run_tests', arguments: { wait: false } })
     );
     writeCustomReport({ suites, stats: firstStats });
+    markReportUpdatedAfter(firstStarted.startedAt);
     first.finish({ code: 0 });
 
     const second = mockNextSpawn(createSpawnControl(2222));
@@ -501,6 +518,7 @@ describe('run_tests — non-blocking status polling', () => {
       await client.callTool({ name: 'run_tests', arguments: { wait: false } })
     );
     writeCustomReport({ suites, stats: secondStats });
+    markReportUpdatedAfter(secondStarted.startedAt);
     second.finish({ code: 0 });
 
     const firstStatus = parseResult(

--- a/test/server.test.ts
+++ b/test/server.test.ts
@@ -512,6 +512,7 @@ describe('run_tests — non-blocking status polling', () => {
     writeCustomReport({ suites, stats: firstStats });
     markReportUpdatedAfter(firstStarted.startedAt);
     first.finish({ code: 0 });
+    await waitForRunEvents();
 
     const second = mockNextSpawn(createSpawnControl(2222));
     const secondStarted = parseResult(
@@ -520,6 +521,7 @@ describe('run_tests — non-blocking status polling', () => {
     writeCustomReport({ suites, stats: secondStats });
     markReportUpdatedAfter(secondStarted.startedAt);
     second.finish({ code: 0 });
+    await waitForRunEvents();
 
     const firstStatus = parseResult(
       await client.callTool({ name: 'get_run_status', arguments: { runId: firstStarted.runId } })
@@ -819,6 +821,7 @@ describe('run_tests — non-blocking status polling', () => {
       if (i === 0) firstRunId = started.runId;
       lastRunId = started.runId;
       run.finish({ code: 0 });
+      await waitForRunEvents();
     }
 
     const result = await client.callTool({


### PR DESCRIPTION
Closes #110

## Summary

- Add `run_tests({ wait: false })` to start a tracked background Playwright run and return status immediately.
- Add `get_run_status` for `runId` polling, latest-run lookup by `workingDirectory`, and idle report-file status when no run is tracked.
- Document the polling workflow and cover active, terminal, timeout, spawn-failure, missing-report, unknown-run, latest-run, and idle-status paths.

## Test plan

- [x] `npm test`
- [x] `npm run build`
- [x] `npx prettier --check README.md index.ts test/server.test.ts`
- [x] `npm run test:e2e` command executed locally; Vitest reported 1 skipped file / 8 skipped tests in this environment.
- [x] Browser-capable e2e environment runs the skipped Playwright-backed tests.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional wait parameter to run_tests for non-blocking background runs.
  * Added get_run_status to monitor runs by runId or retrieve the latest tracked run for a directory.

* **Documentation**
  * Clarified Tools docs: optional workingDirectory semantics, run_tests non-blocking behavior (runId polling/expiration), and get_run_status resolution rules including idle handling.

* **Tests**
  * Added comprehensive tests for non-blocking runs, status polling, lifecycle transitions, timeout/escalation, and related mocks.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hubertgajewski/playwright-report-mcp/pull/111?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->