### PR TITLE
#112 chore: bump to 3.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "playwright-report-mcp",
-  "version": "3.1.4",
+  "version": "3.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "playwright-report-mcp",
-      "version": "3.1.4",
+      "version": "3.2.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "playwright-report-mcp",
-  "version": "3.1.4",
+  "version": "3.2.0",
   "mcpName": "io.github.hubertgajewski/playwright-report-mcp",
   "description": "MCP server for running Playwright tests and reading structured results — designed for AI agents doing test failure analysis",
   "type": "module",

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/hubertgajewski/playwright-report-mcp",
     "source": "github"
   },
-  "version": "3.1.4",
+  "version": "3.2.0",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "playwright-report-mcp",
-      "version": "3.1.4",
+      "version": "3.2.0",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
Closes #112

## Summary

- Bump package metadata from `3.1.4` to `3.2.0`.
- Keep `package.json`, root `package-lock.json`, and `server.json` release metadata in sync for the release workflow and MCP registry publishing.

## Test plan

- [x] `package.json` `version` equals `3.2.0`
- [x] `package-lock.json` root version entries equal `3.2.0`
- [x] `server.json` top-level `version` equals `3.2.0`
- [x] `server.json` `packages[0].version` equals `3.2.0`
- [x] `npm run build`
- [x] `npm test`
- [x] `npx prettier --check package.json package-lock.json server.json`
- [x] GitHub-hosted CI passes
