### PR TITLE
#114 compact get_run_status progress

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ Runs the Playwright test suite and returns structured pass/fail results.
 
 Returns: exit code, run stats, and a summary of all tests with status, duration, and error per project.
 
-When `wait` is `false`, returns immediately with `runId`, process metadata, output tails, and current `results.json` status. Poll `get_run_status` with that `runId` until `state` is `completed`, `failed`, or `timedOut`. The server allows one active tracked run per working directory, caps active tracked runs globally, and keeps a bounded history of recent terminal runs, so very old `runId` values can expire.
+When `wait` is `false`, returns immediately with `runId`, process metadata, compact numeric progress, and current `results.json` status. Poll `get_run_status` with that `runId` until `state` is `completed`, `failed`, or `timedOut`. The server parses Playwright progress markers such as `[528/662]` from stdout and discards raw stdout/stderr text so repeated polling stays token-efficient. The server allows one active tracked run per working directory, caps active tracked runs globally, and keeps a bounded history of recent terminal runs, so very old `runId` values can expire.
 
 ### `get_run_status`
 
@@ -192,7 +192,7 @@ Returns the current status for a non-blocking run started by `run_tests` with `w
 
 If both fields are omitted, `workingDirectory` defaults to `"."`. If no run is tracked for the resolved directory, the tool returns `state: "idle"` plus `results.json` metadata and last parsed stats when readable. It does not process-scan for external `npx playwright test` commands that were not started through this MCP server.
 
-Returns: run state, tracking flag, pid, timestamps, elapsed duration, timeout, command metadata, stdout/stderr tails, exit code, signal, spawn/timeout error when present, `results.json` path/existence/mtime/size/freshness, and parsed report stats when the report was updated after the run started.
+Returns: run state, tracking flag, pid, timestamps, elapsed duration, timeout, command metadata, `progress: { current, total }`, exit code, signal, spawn/timeout error when present, `results.json` path/existence/mtime/size/freshness, and parsed report stats when the report was updated after the run started. When progress has not appeared yet, `current` and `total` are `null`; when a terminal run has readable final stats, progress is set to the derived completed total.
 
 ### `get_failed_tests`
 

--- a/index.ts
+++ b/index.ts
@@ -95,12 +95,18 @@ interface PwReport {
   stats: {
     expected: number;
     unexpected: number;
+    flaky?: number;
     skipped: number;
     duration: number;
   };
 }
 
 type TrackedRunState = 'running' | 'completed' | 'failed' | 'timedOut';
+
+interface RunProgress {
+  current: number | null;
+  total: number | null;
+}
 
 interface ResultsFileStatus {
   path: string;
@@ -120,8 +126,7 @@ interface TrackedRun {
   startedAtMs: number;
   completedAt: string | null;
   timeoutMs: number;
-  stdoutTail: string;
-  stderrTail: string;
+  progress: RunProgress;
   exitCode: number | null;
   signal: NodeJS.Signals | null;
   error: string | null;
@@ -134,7 +139,7 @@ interface TrackedRun {
 const MAX_ACTIVE_RUNS = 4;
 const MAX_TRACKED_RUNS = 50;
 const KILL_ESCALATION_MS = 5_000;
-const RUN_TAIL_LIMIT = 20_000;
+const PROGRESS_CARRY_LIMIT = 64;
 const runs = new Map<string, TrackedRun>();
 
 /**
@@ -241,11 +246,6 @@ function runPlaywright(cmd: string[], cwd: string, timeoutMs: number) {
   });
 }
 
-function appendLimited(current: string, chunk: string, limit: number): string {
-  const combined = current + chunk;
-  return combined.length > limit ? combined.slice(combined.length - limit) : combined;
-}
-
 function nextStableRunId(): string {
   return `run-${randomUUID()}`;
 }
@@ -314,6 +314,28 @@ function captureRunReport(run: TrackedRun) {
     : null;
 }
 
+function emptyProgress(): RunProgress {
+  return { current: null, total: null };
+}
+
+function parseProgress(text: string): RunProgress | null {
+  const matches = Array.from(text.matchAll(/\[(\d+)\/(\d+)\]/g));
+  const last = matches.at(-1);
+  if (!last) return null;
+  return { current: Number(last[1]), total: Number(last[2]) };
+}
+
+function applyProgress(run: TrackedRun, chunk: unknown) {
+  const parsed = parseProgress(String(chunk));
+  if (parsed) run.progress = parsed;
+}
+
+function terminalProgressFromStats(stats: PwReport['stats'] | null): RunProgress | null {
+  if (!stats) return null;
+  const total = stats.expected + stats.unexpected + (stats.flaky ?? 0) + stats.skipped;
+  return { current: total, total };
+}
+
 function signalProcessTree(child: ReturnType<typeof spawn>, signal: NodeJS.Signals) {
   if (child.pid && process.platform !== 'win32') {
     try {
@@ -338,8 +360,7 @@ function startTrackedRun(cmd: string[], cwd: string, timeoutMs: number): Tracked
     startedAtMs: now,
     completedAt: null,
     timeoutMs,
-    stdoutTail: '',
-    stderrTail: '',
+    progress: emptyProgress(),
     exitCode: null,
     signal: null,
     error: null,
@@ -354,6 +375,7 @@ function startTrackedRun(cmd: string[], cwd: string, timeoutMs: number): Tracked
   let child: ReturnType<typeof spawn>;
   let timeoutHandle: ReturnType<typeof setTimeout> | null = null;
   let killEscalationHandle: ReturnType<typeof setTimeout> | null = null;
+  let stdoutProgressCarry = '';
 
   const complete = () => {
     if (settled) return;
@@ -362,16 +384,6 @@ function startTrackedRun(cmd: string[], cwd: string, timeoutMs: number): Tracked
     if (killEscalationHandle && !timedOut) clearTimeout(killEscalationHandle);
     run.completedAt = new Date().toISOString();
     evictOldTrackedRuns();
-  };
-
-  const appendStdout = (chunk: unknown) => {
-    const text = String(chunk);
-    run.stdoutTail = appendLimited(run.stdoutTail, text, RUN_TAIL_LIMIT);
-  };
-
-  const appendStderr = (chunk: unknown) => {
-    const text = String(chunk);
-    run.stderrTail = appendLimited(run.stderrTail, text, RUN_TAIL_LIMIT);
   };
 
   try {
@@ -389,8 +401,12 @@ function startTrackedRun(cmd: string[], cwd: string, timeoutMs: number): Tracked
   }
 
   run.pid = child.pid ?? null;
-  child.stdout?.on('data', appendStdout);
-  child.stderr?.on('data', appendStderr);
+  child.stdout?.on('data', (chunk) => {
+    const text = stdoutProgressCarry + String(chunk);
+    applyProgress(run, text);
+    stdoutProgressCarry = text.slice(-PROGRESS_CARRY_LIMIT);
+  });
+  child.stderr?.resume();
   child.once('error', (e) => {
     if (timedOut) {
       run.state = 'timedOut';
@@ -468,8 +484,8 @@ function runStatus(run: TrackedRun) {
       args: run.cmd.slice(1),
       cwd: run.cwd,
     },
-    stdoutTail: run.stdoutTail,
-    stderrTail: run.stderrTail,
+    progress:
+      run.completedAt === null ? run.progress : (terminalProgressFromStats(stats) ?? run.progress),
     exitCode: run.exitCode,
     signal: run.signal,
     error: run.error,
@@ -489,8 +505,7 @@ function idleStatus(cwd: string) {
     elapsedMs: 0,
     timeoutMs: null,
     command: null,
-    stdoutTail: '',
-    stderrTail: '',
+    progress: emptyProgress(),
     exitCode: null,
     signal: null,
     error: null,

--- a/test/server.test.ts
+++ b/test/server.test.ts
@@ -366,6 +366,9 @@ describe('run_tests — non-blocking status polling', () => {
     expect(data.runId).toMatch(/^run-/);
     expect(data.state).toBe('running');
     expect(data.pid).toBe(4321);
+    expect(data.progress).toEqual({ current: null, total: null });
+    expect(data).not.toHaveProperty('stdoutTail');
+    expect(data).not.toHaveProperty('stderrTail');
     expect(spawnMock).toHaveBeenCalledTimes(1);
     expect(run.child.kill).not.toHaveBeenCalled();
   });
@@ -396,7 +399,48 @@ describe('run_tests — non-blocking status polling', () => {
     expect(status.resultsFile.updatedAfterStart).toBe(false);
     expect(status.resultsFile.mtimeMs).toEqual(expect.any(Number));
     expect(status.stats).toBeNull();
+    expect(status.progress).toEqual({ current: null, total: null });
+    expect(status).not.toHaveProperty('stdoutTail');
+    expect(status).not.toHaveProperty('stderrTail');
     expect(status.elapsedMs).toEqual(expect.any(Number));
+  });
+
+  it('reports compact numeric progress parsed from Playwright stdout', async () => {
+    const run = mockNextSpawn(createSpawnControl(1357));
+    const started = parseResult(
+      await client.callTool({ name: 'run_tests', arguments: { wait: false } })
+    );
+
+    run.child.stdout.write('Running 662 tests using 4 workers\n');
+    run.child.stdout.write('[12/662] [Chromium] › tests/navigation.spec.ts:13:3 › / title\n');
+    run.child.stdout.write('[528/662] [Firefox] › tests/forms.spec.ts:9:1 › form works\n');
+    run.child.stderr.write('warning that should not be retained');
+
+    const status = parseResult(
+      await client.callTool({ name: 'get_run_status', arguments: { runId: started.runId } })
+    );
+
+    expect(status.progress).toEqual({ current: 528, total: 662 });
+    expect(status).not.toHaveProperty('stdoutTail');
+    expect(status).not.toHaveProperty('stderrTail');
+    expect(JSON.stringify(status)).not.toContain('warning that should not be retained');
+  });
+
+  it('parses progress markers split across stdout chunks', async () => {
+    const run = mockNextSpawn(createSpawnControl(1357));
+    const started = parseResult(
+      await client.callTool({ name: 'run_tests', arguments: { wait: false } })
+    );
+
+    run.child.stdout.write('Running 662 tests using 4 workers\n[52');
+    run.child.stdout.write('8/662] [Firefox] › tests/forms.spec.ts:9:1 › form works\n');
+
+    const status = parseResult(
+      await client.callTool({ name: 'get_run_status', arguments: { runId: started.runId } })
+    );
+
+    expect(status.progress).toEqual({ current: 528, total: 662 });
+    expect(JSON.stringify(status)).not.toContain('Running 662 tests');
   });
 
   it('reports live stats for a running run after results.json is updated', async () => {
@@ -476,7 +520,7 @@ describe('run_tests — non-blocking status polling', () => {
     expect(status.resultsFile.exists).toEqual(expect.any(Boolean));
   });
 
-  it('reports terminal failed status with stderr tail and parsed stats', async () => {
+  it('reports terminal failed status with compact progress and parsed stats', async () => {
     const run = mockNextSpawn(createSpawnControl());
     const started = parseResult(
       await client.callTool({ name: 'run_tests', arguments: { wait: false } })
@@ -495,10 +539,33 @@ describe('run_tests — non-blocking status polling', () => {
       state: 'failed',
       exitCode: 1,
       signal: null,
-      stderrTail: 'one test failed',
       stats,
+      progress: { current: 2, total: 2 },
     });
+    expect(status).not.toHaveProperty('stdoutTail');
+    expect(status).not.toHaveProperty('stderrTail');
+    expect(JSON.stringify(status)).not.toContain('one test failed');
     expect(status.completedAt).toEqual(expect.any(String));
+  });
+
+  it('includes flaky tests when deriving terminal progress from stats', async () => {
+    const flakyStats = { expected: 1, unexpected: 0, flaky: 1, skipped: 1, duration: 4000 };
+    const run = mockNextSpawn(createSpawnControl());
+    const started = parseResult(
+      await client.callTool({ name: 'run_tests', arguments: { wait: false } })
+    );
+
+    writeCustomReport({ suites, stats: flakyStats });
+    markReportUpdatedAfter(started.startedAt);
+    run.finish({ code: 0 });
+    await waitForRunEvents();
+
+    const status = parseResult(
+      await client.callTool({ name: 'get_run_status', arguments: { runId: started.runId } })
+    );
+
+    expect(status.stats).toEqual(flakyStats);
+    expect(status.progress).toEqual({ current: 3, total: 3 });
   });
 
   it('keeps report stats isolated to the run that produced them', async () => {
@@ -640,6 +707,7 @@ describe('run_tests — non-blocking status polling', () => {
   });
 
   it('reports spawn failure status', async () => {
+    deleteReport();
     const run = mockNextSpawn(createSpawnControl());
     const started = parseResult(
       await client.callTool({ name: 'run_tests', arguments: { wait: false } })
@@ -654,6 +722,9 @@ describe('run_tests — non-blocking status polling', () => {
     expect(status.state).toBe('failed');
     expect(status.error).toContain('Failed to spawn Playwright');
     expect(status.error).toContain('ENOENT');
+    expect(status.progress).toEqual({ current: null, total: null });
+    expect(status).not.toHaveProperty('stdoutTail');
+    expect(status).not.toHaveProperty('stderrTail');
   });
 
   it('reports synchronous spawn exceptions as failed tracked runs', async () => {


### PR DESCRIPTION
Closes #114

## Summary

- Replace `get_run_status` stdout/stderr tails with compact `progress: { current, total }`.
- Parse Playwright progress markers from stdout without retaining raw output, including markers split across chunks.
- Derive terminal progress from final stats, including flaky tests, and document the compact polling response.

## Test plan

- [x] `npm test`
- [x] `npm run build`
- [x] `npx prettier --check README.md index.ts test/server.test.ts`
- [x] `$deep-review-pro` review completed; blocking findings fixed and re-reviewed where available
- [x] GitHub-hosted CI passes

Note: full local `npm run format:check` still reports the unrelated untracked `CLAUDE.md`; it is not part of this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Test runs now display progress tracking with current/total test count metrics.

* **API Changes**
  * Status API responses now include a progress field with current and total test counts (returns null before tests begin).
  * Status responses no longer include stdout/stderr tail output.

* **Documentation**
  * Updated documentation describing test progress reporting behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hubertgajewski/playwright-report-mcp/pull/115?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->