### PR TITLE
#116 chore: bump to 3.2.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "playwright-report-mcp",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "playwright-report-mcp",
-      "version": "3.2.0",
+      "version": "3.2.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "playwright-report-mcp",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "mcpName": "io.github.hubertgajewski/playwright-report-mcp",
   "description": "MCP server for running Playwright tests and reading structured results — designed for AI agents doing test failure analysis",
   "type": "module",

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/hubertgajewski/playwright-report-mcp",
     "source": "github"
   },
-  "version": "3.2.0",
+  "version": "3.2.1",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "playwright-report-mcp",
-      "version": "3.2.0",
+      "version": "3.2.1",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
Closes #116

## Summary

- Bump package metadata from `3.2.0` to `3.2.1`.
- Keep npm package and MCP registry versions in sync.

## Test plan

- [x] `npm run build`
- [x] `npm test`
- [x] `npx prettier --check package.json package-lock.json server.json`
