### PR TITLE
Bump version to 3.3.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "playwright-report-mcp",
-  "version": "3.2.2",
+  "version": "3.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "playwright-report-mcp",
-      "version": "3.2.2",
+      "version": "3.3.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/server": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "playwright-report-mcp",
-  "version": "3.2.2",
+  "version": "3.3.0",
   "mcpName": "io.github.hubertgajewski/playwright-report-mcp",
   "description": "MCP server for running Playwright tests and reading structured results — designed for AI agents doing test failure analysis",
   "type": "module",

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/hubertgajewski/playwright-report-mcp",
     "source": "github"
   },
-  "version": "3.2.2",
+  "version": "3.3.0",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "playwright-report-mcp",
-      "version": "3.2.2",
+      "version": "3.3.0",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
## Problem

The dual-era MCP protocol support from #146 has landed, but the package and MCP registry metadata still identify the project as version `3.2.2`.

## Solution

- bump `package.json` and both root `package-lock.json` version entries to `3.3.0`
- bump the top-level and package versions in `server.json` to `3.3.0`
- keep release tagging and publishing out of this PR

## User-visible changes

The next published package and MCP registry entry will be identified as `3.3.0`, reflecting the backward-compatible MCP `2026-07-28` support while legacy clients remain supported.

## Test plan

- [x] `npm run build`
- [x] `npm test` (165 tests)
- [x] `npm run format:check`
- [x] `npm pack --dry-run --json` reports `playwright-report-mcp@3.3.0` and includes the expected compiled `dist/` modules
- [x] Independently assert all five release version fields equal `3.3.0`
- [x] `git diff --check`

Closes #148
