### PR TITLE
Extend MCP registry smoke-check retry window

### DIFF
--- a/.github/workflows/publish-mcp.yml
+++ b/.github/workflows/publish-mcp.yml
@@ -17,6 +17,7 @@ jobs:
       github.event.workflow_run.conclusion == 'success' &&
       github.event.workflow_run.event == 'push'
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     env:
       MCP_REGISTRY_SEARCH_URL: https://registry.modelcontextprotocol.io/v0.1/servers
     steps:
@@ -89,17 +90,32 @@ jobs:
         env:
           NAME: ${{ steps.meta.outputs.name }}
           VERSION: ${{ steps.meta.outputs.version }}
+          MAX_ATTEMPTS: 12
+          RETRY_DELAY_SECONDS: 10
         run: |
           set -euo pipefail
-          for attempt in 1 2 3; do
-            FOUND=$(curl -sSfL --get "${MCP_REGISTRY_SEARCH_URL}" --data-urlencode "search=$NAME" \
-              | jq -r --arg n "$NAME" --arg v "$VERSION" '[.servers[]? | select(.server.name == $n and .server.version == $v)] | length')
-            if [ "$FOUND" != "0" ]; then
-              echo "Published ${NAME}@${VERSION} is visible in the registry (attempt ${attempt})."
-              exit 0
+
+          for attempt in $(seq 1 "$MAX_ATTEMPTS"); do
+            if RESPONSE=$(curl -sSfL --get "${MCP_REGISTRY_SEARCH_URL}" --data-urlencode "search=$NAME"); then
+              if FOUND=$(jq -r --arg n "$NAME" --arg v "$VERSION" \
+                '[.servers[]? | select(.server.name == $n and .server.version == $v)] | length' <<<"$RESPONSE"); then
+                if [ "$FOUND" != "0" ]; then
+                  echo "Published ${NAME}@${VERSION} is visible in the registry (attempt ${attempt}/${MAX_ATTEMPTS})."
+                  exit 0
+                fi
+              else
+                echo "::warning::Registry search returned an invalid response on attempt ${attempt}/${MAX_ATTEMPTS}."
+              fi
+            else
+              echo "::warning::Registry search failed on attempt ${attempt}/${MAX_ATTEMPTS}."
             fi
-            echo "Attempt ${attempt}: ${NAME}@${VERSION} not yet visible; sleeping 5s."
-            sleep 5
+
+            if [ "$attempt" -lt "$MAX_ATTEMPTS" ]; then
+              echo "Attempt ${attempt}/${MAX_ATTEMPTS}: ${NAME}@${VERSION} not yet visible; sleeping ${RETRY_DELAY_SECONDS}s."
+              sleep "$RETRY_DELAY_SECONDS"
+            fi
           done
-          echo "::error::Published but ${NAME}@${VERSION} not visible in the MCP registry search after 3 attempts."
+
+          MAX_WAIT_SECONDS=$(( (MAX_ATTEMPTS - 1) * RETRY_DELAY_SECONDS ))
+          echo "::error::Published ${NAME}@${VERSION} was not visible after ${MAX_ATTEMPTS} attempts over ${MAX_WAIT_SECONDS}s."
           exit 1

--- a/.github/workflows/publish-mcp.yml
+++ b/.github/workflows/publish-mcp.yml
@@ -95,10 +95,15 @@ jobs:
         run: |
           set -euo pipefail
 
-          for attempt in $(seq 1 "$MAX_ATTEMPTS"); do
-            if RESPONSE=$(curl -sSfL --get "${MCP_REGISTRY_SEARCH_URL}" --data-urlencode "search=$NAME"); then
+          for ((attempt = 1; attempt <= MAX_ATTEMPTS; attempt++)); do
+            if RESPONSE=$(curl -sSfL --connect-timeout 5 --max-time 10 --get \
+              "${MCP_REGISTRY_SEARCH_URL}" --data-urlencode "search=$NAME"); then
               if FOUND=$(jq -r --arg n "$NAME" --arg v "$VERSION" \
-                '[.servers[]? | select(.server.name == $n and .server.version == $v)] | length' <<<"$RESPONSE"); then
+                'if (.servers | type) == "array" then
+                  [.servers[] | select(.server.name == $n and .server.version == $v)] | length
+                else
+                  error("expected .servers to be an array")
+                end' <<<"$RESPONSE"); then
                 if [ "$FOUND" != "0" ]; then
                   echo "Published ${NAME}@${VERSION} is visible in the registry (attempt ${attempt}/${MAX_ATTEMPTS})."
                   exit 0

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 dist/
 node_modules/
 coverage/
+.deep-review-cache/
 test/fixtures/test-results/
 test/fixtures/pw-project/node_modules/
 test/fixtures/pw-project/test-results/


### PR DESCRIPTION
## Problem

The MCP registry publish in [run 31577349819](https://github.com/hubertgajewski/playwright-report-mcp/actions/runs/31577349819) succeeded, but the workflow failed because three short search checks ended before registry indexing completed.

## Solution

- poll registry search up to 12 times at 10-second intervals
- bound each registry request with connection and total-transfer deadlines
- retry transient HTTP and invalid-response failures with clear warnings
- require the registry response to contain a `servers` array
- fail with the server, version, attempt count, and total wait window
- skip sleeping after the final attempt
- bound the publish job with a 10-minute timeout

The existing publication guard, pinned/checksummed publisher installation, OIDC authentication, and release-SHA checkout remain unchanged.

## Test plan

- [x] `npm run build`
- [x] `npm test` (165 tests)
- [x] `npm run format:check`
- [x] Simulate a transient HTTP failure followed by an invalid response, delayed absence, and eventual visibility
- [x] Reject missing, null, and non-array `servers` values while accepting valid arrays
- [x] Verify every poll uses bounded connection and total-transfer timeouts
- [x] Simulate persistent absence and verify actionable failure output
- [x] Verify three failed attempts sleep exactly twice
- [x] Verify `.deep-review-cache/` is ignored
- [x] `git diff --check`

Closes #150
