### PR TITLE
#153 ci: ensure CodeQL analyzes Dependabot pull requests

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,40 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: '17 3 * * 4'
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      security-events: write
+      packages: read
+      actions: read
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - language: actions
+            build-mode: none
+          - language: javascript-typescript
+            build-mode: none
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v4
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+      - name: Perform CodeQL analysis
+        uses: github/codeql-action/analyze@v4
+        with:
+          category: /language:${{ matrix.language }}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -28,13 +28,15 @@ jobs:
             build-mode: none
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v4
+        uses: github/codeql-action/init@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
       - name: Perform CodeQL analysis
-        uses: github/codeql-action/analyze@v4
+        uses: github/codeql-action/analyze@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
         with:
           category: /language:${{ matrix.language }}


### PR DESCRIPTION
## Problem

GitHub-managed CodeQL default setup produces neutral “configurations not found” checks for lockfile-only Dependabot pull requests because no pull-request analysis is scheduled for the configurations present on `main`.

## Solution

- add an explicit advanced-setup CodeQL workflow
- analyze GitHub Actions and JavaScript/TypeScript on pushes to `main`, pull requests targeting `main`, and a weekly schedule
- use stable language categories and least-privilege permissions
- bound each matrix job with a 10-minute timeout

Closes #153

## Test plan

- [x] Run `npm ci`
- [x] Run `npm run format:check`
- [x] Run `npm run build`
- [x] Run `npm test` (165 tests)
- [x] Verify both CodeQL matrix jobs complete after switching the repository to advanced setup
- [x] Verify successful `main` baseline analyses after merge
- [ ] Re-trigger a lockfile-only Dependabot PR and confirm it receives conclusive CodeQL jobs without “configurations not found”


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated security analysis for JavaScript/TypeScript and workflow code.
  * Security checks now run on changes to the main branch and pull requests.
  * Added a weekly scheduled security scan.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->